### PR TITLE
[ISSUE - 76] 정보 수정 diff방식으로 변경(중복키 에러 해결)

### DIFF
--- a/refit-backend/src/main/java/org/refit/refitbackend/domain/user/entity/UserSkill.java
+++ b/refit-backend/src/main/java/org/refit/refitbackend/domain/user/entity/UserSkill.java
@@ -45,4 +45,9 @@ public class UserSkill extends BaseEntity {
         return new UserSkill(user, skill, displayOrder);
     }
 
+    public void updateDisplayOrder(Integer displayOrder) {
+        if (displayOrder != null) {
+            this.displayOrder = displayOrder;
+        }
+    }
 }

--- a/refit-backend/src/main/java/org/refit/refitbackend/domain/user/repository/UserJobRepository.java
+++ b/refit-backend/src/main/java/org/refit/refitbackend/domain/user/repository/UserJobRepository.java
@@ -10,6 +10,8 @@ import java.util.List;
 
 @Repository
 public interface UserJobRepository extends JpaRepository<UserJob, Integer> {
+    void deleteByUser_Id(Long userId);
+
     @Query("""
       SELECT uj FROM UserJob uj
       JOIN FETCH uj.job

--- a/refit-backend/src/main/java/org/refit/refitbackend/domain/user/repository/UserSkillRepository.java
+++ b/refit-backend/src/main/java/org/refit/refitbackend/domain/user/repository/UserSkillRepository.java
@@ -10,6 +10,8 @@ import java.util.List;
 
 @Repository
 public interface UserSkillRepository extends JpaRepository<UserSkill, Integer> {
+    void deleteByUser_Id(Long userId);
+
     @Query("""
       SELECT us FROM UserSkill us
       JOIN FETCH us.skill


### PR DESCRIPTION
## 변경 사항

  - 내 정보 수정 시 직무/스킬 갱신 로직을 diff 기반으로 개선
  - 스킬 display_order 변경 시 기존 데이터 갱신 처리

  ## 상세 내용

  - 기존 전면 삭제/재삽입 방식에서 비교 업데이트 방식으로 변경해 중복키 에러 방지
  - 요청된 직무/스킬과 기존 데이터 비교 후 삭제/추가/순서 갱신 수행

  ## 체크리스트

  - [x] 기능이 정상적으로 동작하는지 확인했습니다.
  - [x] 기존 기능에 영향을 주지 않는지 확인했습니다.

  ## 리뷰 요청 사항

  - 

  ## 연관된 이슈

  > #64                                                                                                                                                                                                                                 

  ## 참고 자료 (선택)

  - 없음