### PR TITLE
[ISSUE - #90] 클라이언트 메시지 중복처리 방지

### DIFF
--- a/refit-backend/src/main/java/org/refit/refitbackend/domain/chat/dto/ChatReq.java
+++ b/refit-backend/src/main/java/org/refit/refitbackend/domain/chat/dto/ChatReq.java
@@ -40,7 +40,10 @@ public class ChatReq {
             String content,
 
             @Schema(description = "메시지 타입", example = "TEXT")
-            String messageType  // TEXT, FILE, SYSTEM
+            String messageType,  // TEXT, FILE, SYSTEM
+
+            @Schema(description = "클라이언트 메시지 ID (중복 방지용)", example = "cmsg_1700000000000")
+            String clientMessageId
     ) {}
 
     @Schema(description = "메시지 읽음 처리 요청")


### PR DESCRIPTION
  ## 변경 사항

  - WebSocket 메시지 요청 DTO에 client_message_id 필드 추가

  ## 상세 내용

  - ChatReq.SendMessage에 client_message_id를 추가해 프론트에서 중복 방지용 식별자를 전달할 수 있도록 함
  - Jackson 역직렬화 오류 방지 및 메시지 전송 안정화

  ## 체크리스트

  - [x] 기능이 정상적으로 동작하는지 확인했습니다.
  - [x] 기존 기능에 영향을 주지 않는지 확인했습니다.

  ## 리뷰 요청 사항

  - 

  ## 연관된 이슈

  - #90 


  ## 참고 자료 (선택)

  - 없음