### PR TITLE
[ISSUE - #110] 이메일 인증 도메인 화이트리스트 적용

### DIFF
--- a/refit-backend/src/main/java/org/refit/refitbackend/domain/auth/service/EmailVerificationService.java
+++ b/refit-backend/src/main/java/org/refit/refitbackend/domain/auth/service/EmailVerificationService.java
@@ -183,6 +183,9 @@ public class EmailVerificationService {
         if (FREE_EMAIL_DOMAINS.contains(domain)) {
             throw new CustomException(ExceptionType.EMAIL_NOT_COMPANY_EMAIL);
         }
+        if (!emailDomainRepository.existsById(domain)) {
+            throw new CustomException(ExceptionType.EMAIL_DOMAIN_NOT_ALLOWED);
+        }
     }
 
     private String generateCode() {


### PR DESCRIPTION
 ## 변경 사항
  - 이메일 인증 요청에서 등록되지 않은 도메인 차단

  ## 상세 내용
  - EmailDomainRepository에 없는 도메인은 public/인증 API 모두에서 거절하도록 검증 로직 추가
  - 기존 무료/임시 이메일 차단 정책 유지

  ## 체크리스트
  - [x] 기능이 정상적으로 동작하는지 확인했습니다.
  - [x] 기존 기능에 영향을 주지 않는지 확인했습니다.

  ## 리뷰 요청 사항
  - 

  ## 연관된 이슈
  - #110 

  ## 참고 자료 (선택)
  - 없음