### PR TITLE
[ISSUE - #119] 프로필 이미지 업로드 파일 크기 검증

### DIFF
--- a/refit-backend/src/main/java/org/refit/refitbackend/domain/storage/service/StorageService.java
+++ b/refit-backend/src/main/java/org/refit/refitbackend/domain/storage/service/StorageService.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 public class StorageService {
 
     private static final long MAX_RESUME_BYTES = 5L * 1024 * 1024;
+    private static final long MAX_PROFILE_IMAGE_BYTES = 10L * 1024 * 1024;
 
     private final StorageClient storageClient;
     private final ResumeRepository resumeRepository;
@@ -92,11 +93,18 @@ public class StorageService {
 
     private void validateUploadSize(StorageReq.PresignedUrlRequest request) {
         Long fileSize = request.fileSize();
-        if (fileSize == null || fileSize < 0) {
-            throw new CustomException(ExceptionType.INVALID_REQUEST);
+        if (fileSize == null) {
+            throw new CustomException(ExceptionType.FILE_SIZE_REQUIRED);
+        }
+        if (fileSize < 0) {
+            throw new CustomException(ExceptionType.FILE_SIZE_INVALID);
         }
         if (request.targetType() == StorageReq.UploadTarget.RESUME_PDF && fileSize > MAX_RESUME_BYTES) {
             throw new CustomException(ExceptionType.RESUME_FILE_TOO_LARGE);
+        }
+        if (request.targetType() == StorageReq.UploadTarget.PROFILE_IMAGE
+                && fileSize > MAX_PROFILE_IMAGE_BYTES) {
+            throw new CustomException(ExceptionType.PROFILE_IMAGE_TOO_LARGE);
         }
     }
 

--- a/refit-backend/src/main/java/org/refit/refitbackend/global/error/ExceptionType.java
+++ b/refit-backend/src/main/java/org/refit/refitbackend/global/error/ExceptionType.java
@@ -37,6 +37,8 @@ public enum ExceptionType {
     FILE_TYPE_INVALID(HttpStatus.BAD_REQUEST, "FILE_TYPE_INVALID", "지원하지 않는 파일 형식입니다."),
     CONTENT_TYPE_INVALID(HttpStatus.BAD_REQUEST, "CONTENT_TYPE_INVALID", "지원하지 않는 콘텐츠 타입입니다."),
     FILE_NAME_EMPTY(HttpStatus.BAD_REQUEST, "FILE_NAME_EMPTY", "파일명이 필요합니다."),
+    FILE_SIZE_REQUIRED(HttpStatus.BAD_REQUEST, "FILE_SIZE_REQUIRED", "파일 크기가 필요합니다."),
+    FILE_SIZE_INVALID(HttpStatus.BAD_REQUEST, "FILE_SIZE_INVALID", "파일 크기가 올바르지 않습니다."),
 
     /* =======================
      * Signup / Auth
@@ -69,6 +71,7 @@ public enum ExceptionType {
 
     IMAGE_URL_INVALID(HttpStatus.BAD_REQUEST, "IMAGE_URL_INVALID", "이미지 URL 형식이 올바르지 않습니다."),
     IMAGE_URL_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "IMAGE_URL_NOT_ALLOWED", "허용되지 않은 이미지 URL 도메인입니다."),
+    PROFILE_IMAGE_TOO_LARGE(HttpStatus.BAD_REQUEST, "PROFILE_IMAGE_TOO_LARGE", "프로필 이미지 용량이 너무 큽니다."),
 
     /* =======================
      * Job / Skill / Career

--- a/refit-backend/src/main/java/org/refit/refitbackend/global/swagger/spec/storage/StorageSwaggerSpec.java
+++ b/refit-backend/src/main/java/org/refit/refitbackend/global/swagger/spec/storage/StorageSwaggerSpec.java
@@ -26,7 +26,10 @@ public final class StorageSwaggerSpec {
     )
     @SwaggerApiBadRequestError(types = {
             ExceptionType.INVALID_REQUEST,
-            ExceptionType.RESUME_FILE_TOO_LARGE
+            ExceptionType.FILE_SIZE_REQUIRED,
+            ExceptionType.FILE_SIZE_INVALID,
+            ExceptionType.RESUME_FILE_TOO_LARGE,
+            ExceptionType.PROFILE_IMAGE_TOO_LARGE
     })
     @SwaggerApiUnauthorizedError(types = {
             ExceptionType.AUTH_UNAUTHORIZED


### PR DESCRIPTION
 ## 변경 사항

  - 업로드 요청의 파일 크기 오류 응답 코드를 세분화

  ## 상세 내용

  - FILE_SIZE_REQUIRED, FILE_SIZE_INVALID 오류 코드 추가
  - 업로드 요청에서 파일 크기 누락/음수에 대해 명확한 에러 반환
  - Swagger 문서에 신규 에러 코드 반영

  ## 체크리스트

  - [x] 기능이 정상적으로 동작하는지 확인했습니다.
  - [x] 기존 기능에 영향을 주지 않는지 확인했습니다.

  ## 리뷰 요청 사항

  - 

  ## 연관된 이슈

  > #119 

  ## 참고 자료 (선택)

  - 없음