### PR TITLE
release: v1.0.1 (#123)

### DIFF
--- a/refit-backend/src/main/java/org/refit/refitbackend/domain/chat/controller/ChatRoomController.java
+++ b/refit-backend/src/main/java/org/refit/refitbackend/domain/chat/controller/ChatRoomController.java
@@ -128,12 +128,14 @@ public class ChatRoomController {
      * 메시지 읽음 처리
      */
     @ChatSwaggerSpec.MarkAsRead
-    @PatchMapping("/messages/read")
+    @PatchMapping("/{chat_id}/last-read-message")
     public ResponseEntity<ApiResponse<Void>> markAsRead(
             @AuthenticationPrincipal CustomUserDetails principal,
+            @Parameter(description = "채팅방 ID", example = "1", required = true)
+            @PathVariable("chat_id") Long chatId,
             @Valid @RequestBody ChatReq.ReadMessage request
     ) {
-        chatRoomService.markAsRead(principal.getUserId(), request);
+        chatRoomService.markAsRead(principal.getUserId(), chatId, request);
         return ResponseUtil.ok("success", null);
     }
 }

--- a/refit-backend/src/main/java/org/refit/refitbackend/domain/chat/dto/ChatReq.java
+++ b/refit-backend/src/main/java/org/refit/refitbackend/domain/chat/dto/ChatReq.java
@@ -49,13 +49,9 @@ public class ChatReq {
     @Schema(description = "메시지 읽음 처리 요청")
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     public record ReadMessage(
-            @Schema(description = "채팅방 ID", example = "1")
-            @NotNull(message = "채팅 ID가 필요합니다.")
-            Long chatId,
-
-            @Schema(description = "읽은 메시지 ID", example = "100")
+            @Schema(description = "마지막으로 읽은 메시지 ID", example = "100")
             @NotNull(message = "메시지 ID가 필요합니다.")
-            Long messageId
+            Long lastMessageId
     ) {}
 
     @Schema(description = "채팅방 종료 요청")

--- a/refit-backend/src/main/java/org/refit/refitbackend/domain/chat/service/ChatMessageService.java
+++ b/refit-backend/src/main/java/org/refit/refitbackend/domain/chat/service/ChatMessageService.java
@@ -62,6 +62,8 @@ public class ChatMessageService {
 
         // 채팅방의 마지막 메시지 업데이트
         chatRoom.updateLastMessage(savedMessage);
+        // 발신자 기준으로 읽음 처리까지 반영
+        chatRoom.updateLastReadMessage(senderId, savedMessage);
 
         ChatRes.MessageInfo payload = ChatRes.MessageInfo.from(savedMessage);
 

--- a/refit-backend/src/main/java/org/refit/refitbackend/domain/chat/service/ChatRoomService.java
+++ b/refit-backend/src/main/java/org/refit/refitbackend/domain/chat/service/ChatRoomService.java
@@ -190,11 +190,11 @@ public class ChatRoomService {
      * 메시지 읽음 처리
      */
     @Transactional
-    public void markAsRead(Long userId, ChatReq.ReadMessage request) {
-        ChatRoom room = chatRoomRepository.findByIdAndUserId(request.chatId(), userId)
+    public void markAsRead(Long userId, Long roomId, ChatReq.ReadMessage request) {
+        ChatRoom room = chatRoomRepository.findByIdAndUserId(roomId, userId)
                 .orElseThrow(() -> new CustomException(ExceptionType.CHAT_ROOM_NOT_FOUND));
 
-        ChatMessage message = chatMessageRepository.findById(request.messageId())
+        ChatMessage message = chatMessageRepository.findById(request.lastMessageId())
                 .orElseThrow(() -> new CustomException(ExceptionType.MESSAGE_NOT_FOUND));
 
         room.updateLastReadMessage(userId, message);

--- a/refit-backend/src/main/java/org/refit/refitbackend/domain/storage/service/StorageService.java
+++ b/refit-backend/src/main/java/org/refit/refitbackend/domain/storage/service/StorageService.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 public class StorageService {
 
     private static final long MAX_RESUME_BYTES = 5L * 1024 * 1024;
+    private static final long MAX_PROFILE_IMAGE_BYTES = 10L * 1024 * 1024;
 
     private final StorageClient storageClient;
     private final ResumeRepository resumeRepository;
@@ -92,11 +93,18 @@ public class StorageService {
 
     private void validateUploadSize(StorageReq.PresignedUrlRequest request) {
         Long fileSize = request.fileSize();
-        if (fileSize == null || fileSize < 0) {
-            throw new CustomException(ExceptionType.INVALID_REQUEST);
+        if (fileSize == null) {
+            throw new CustomException(ExceptionType.FILE_SIZE_REQUIRED);
+        }
+        if (fileSize < 0) {
+            throw new CustomException(ExceptionType.FILE_SIZE_INVALID);
         }
         if (request.targetType() == StorageReq.UploadTarget.RESUME_PDF && fileSize > MAX_RESUME_BYTES) {
             throw new CustomException(ExceptionType.RESUME_FILE_TOO_LARGE);
+        }
+        if (request.targetType() == StorageReq.UploadTarget.PROFILE_IMAGE
+                && fileSize > MAX_PROFILE_IMAGE_BYTES) {
+            throw new CustomException(ExceptionType.PROFILE_IMAGE_TOO_LARGE);
         }
     }
 

--- a/refit-backend/src/main/java/org/refit/refitbackend/global/error/ExceptionType.java
+++ b/refit-backend/src/main/java/org/refit/refitbackend/global/error/ExceptionType.java
@@ -37,6 +37,8 @@ public enum ExceptionType {
     FILE_TYPE_INVALID(HttpStatus.BAD_REQUEST, "FILE_TYPE_INVALID", "지원하지 않는 파일 형식입니다."),
     CONTENT_TYPE_INVALID(HttpStatus.BAD_REQUEST, "CONTENT_TYPE_INVALID", "지원하지 않는 콘텐츠 타입입니다."),
     FILE_NAME_EMPTY(HttpStatus.BAD_REQUEST, "FILE_NAME_EMPTY", "파일명이 필요합니다."),
+    FILE_SIZE_REQUIRED(HttpStatus.BAD_REQUEST, "FILE_SIZE_REQUIRED", "파일 크기가 필요합니다."),
+    FILE_SIZE_INVALID(HttpStatus.BAD_REQUEST, "FILE_SIZE_INVALID", "파일 크기가 올바르지 않습니다."),
 
     /* =======================
      * Signup / Auth
@@ -69,6 +71,7 @@ public enum ExceptionType {
 
     IMAGE_URL_INVALID(HttpStatus.BAD_REQUEST, "IMAGE_URL_INVALID", "이미지 URL 형식이 올바르지 않습니다."),
     IMAGE_URL_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "IMAGE_URL_NOT_ALLOWED", "허용되지 않은 이미지 URL 도메인입니다."),
+    PROFILE_IMAGE_TOO_LARGE(HttpStatus.BAD_REQUEST, "PROFILE_IMAGE_TOO_LARGE", "프로필 이미지 용량이 너무 큽니다."),
 
     /* =======================
      * Job / Skill / Career

--- a/refit-backend/src/main/java/org/refit/refitbackend/global/swagger/spec/chat/ChatSwaggerSpec.java
+++ b/refit-backend/src/main/java/org/refit/refitbackend/global/swagger/spec/chat/ChatSwaggerSpec.java
@@ -141,13 +141,11 @@ public final class ChatSwaggerSpec {
     @Retention(RetentionPolicy.RUNTIME)
     @SwaggerApiSuccess(
             summary = "메시지 읽음 처리",
-            operationDescription = "메시지를 읽음 처리합니다",
+            operationDescription = "채팅방의 마지막 읽은 메시지를 갱신합니다",
             implementation = ApiResponse.class
     )
     @SwaggerApiError(responseCode = "400", description = "invalid_request", types = {
             ExceptionType.INVALID_REQUEST,
-            ExceptionType.MESSAGE_CONTENT_EMPTY,
-            ExceptionType.MESSAGE_CONTENT_TOO_LONG,
             ExceptionType.MESSAGE_ID_REQUIRED
     })
     @SwaggerApiError(responseCode = "401", description = "unauthorized", types = {
@@ -160,7 +158,8 @@ public final class ChatSwaggerSpec {
             ExceptionType.AUTH_FORBIDDEN
     })
     @SwaggerApiError(responseCode = "404", description = "message_not_found", types = {
-            ExceptionType.MESSAGE_NOT_FOUND
+            ExceptionType.MESSAGE_NOT_FOUND,
+            ExceptionType.CHAT_ROOM_NOT_FOUND
     })
     public @interface MarkAsRead {}
 

--- a/refit-backend/src/main/java/org/refit/refitbackend/global/swagger/spec/storage/StorageSwaggerSpec.java
+++ b/refit-backend/src/main/java/org/refit/refitbackend/global/swagger/spec/storage/StorageSwaggerSpec.java
@@ -26,7 +26,10 @@ public final class StorageSwaggerSpec {
     )
     @SwaggerApiBadRequestError(types = {
             ExceptionType.INVALID_REQUEST,
-            ExceptionType.RESUME_FILE_TOO_LARGE
+            ExceptionType.FILE_SIZE_REQUIRED,
+            ExceptionType.FILE_SIZE_INVALID,
+            ExceptionType.RESUME_FILE_TOO_LARGE,
+            ExceptionType.PROFILE_IMAGE_TOO_LARGE
     })
     @SwaggerApiUnauthorizedError(types = {
             ExceptionType.AUTH_UNAUTHORIZED


### PR DESCRIPTION
* feat: 공통 응답 Response 구현

* feat: 전역 예외 처리 구

* feat: 기본 BaseEntity 구현

* chore: SwaggerConfig 추가

* feat: User 기본 구조 구현

* feat: 마스터 테이블 기본 구조 구현

* feat: User-마스터테이블 연관관계 테이블 구현

* feat: Oauth 회원가입/로그인 구현

* chore: yml, 의존성 수

* chore: yml, 의존성 수정

* chore: SecurityConfig, CorsConfig 초안 작성

* chore: Oauth관련 minor commit

* test: local Oauth 테스트 페이지

* feat: 회원 및 마스터 테이블 조회 기능 추가 (#12)

* feat: 회원 조회 관련 기능 추

* feat: 마스터 테이블 조회 기능 추가
- 직무, 경력은 테이블 전체 조회
- 기술은 파라미터에 따라 조건 검

* chore: cors, prod 설정

* feat: 의존성 추가 및 config (#14)

* feat: 회원 조회 관련 기능 추

* feat: 마스터 테이블 조회 기능 추가
- 직무, 경력은 테이블 전체 조회
- 기술은 파라미터에 따라 조건 검

* chore: cors, prod 설정

* chore: jwt 관련 의존성 및 yml 설정

* fix: EnableConfigurationProperties Config설정

* ci: CI/CD 워크플로우 파일 추가

* Update issue templates

* fix: Swagger, Security Conifg 수정 (#16)

* feat: 회원 조회 관련 기능 추

* feat: 마스터 테이블 조회 기능 추가
- 직무, 경력은 테이블 전체 조회
- 기술은 파라미터에 따라 조건 검

* chore: cors, prod 설정

* chore: jwt 관련 의존성 및 yml 설정

* fix: EnableConfigurationProperties Config설정

* fix: Swagger, Security Config 수정 #15

* fix: conflict fix

* fix: ddl-auto fix

* chore: application-secret.yml 파일 주입으로 변경

- 기존: application-oauth2.yml, application-prod.yml 파일 주입
- 변경: 모든 secret을 application-secret.yml로 관리하여 각 파일에 주입되도록 변경

* ci: CI/CD 워크플로우 개선

- 시크릿 파일을 application-secret.yml 하나로 통합
- 서버 경로를 SERVER_BASE_PATH로 통합 관리
- CI에서 빌드한 아티팩트를 반드시 사용하도록 변경
- workflow_dispatch와 workflow_run 분리 처리
- 아티팩트 다운로드 실패 시 명확한 에러 메시지 제공

* fix: CD 워크플로우 checkout token 에러 수정

- workflow_run과 workflow_dispatch에 따라 checkout 단계 분리
- workflow_run일 때만 PAT 토큰 사용

* fix: CD 배포 검증 개선 - 대기 시간 단축 및 디버깅 정보 추가

- 배포 검증 대기 시간 15초에서 10초로 단축
- HTTP Status Code 출력 추가
- 배포 실패 시 PM2 상태 및 로그 출력 추가

* refactor: Spring Boot 설정 파일 구조 개선 및 optional import 추가

- application.yml: spring.config.import로 application-secret.yml을 optional로 추가
- spring.profiles.include에서 secret 제거하여 중복 방지
- application-prod.yml에서 중복된 datasource 설정 제거
- application-secret.yml의 Spring Boot 설정 구조가 정상적으로 로드되도록 개선

* refactor: CI/CD 워크플로우 예외 처리 및 안정성 개선

CD 워크플로우:
- 헬스 체크 재시도 로직 추가 (최대 3회, 총 25초 대기)
- 파일 복사 및 디렉토리 생성 실패 시 에러 처리 추가
- PM2 시작 확인 로직 개선
- Caddy 리로드 실패 시 경고 메시지 출력
- PAT 제거하여 기본 GITHUB_TOKEN 사용

CI 워크플로우:
- 모든 Gradle 명령어 실패 시 명확한 에러 메시지 출력
- Dependency Vulnerability Check에 continue-on-error 추가
- JAR 검증 단계 예외 처리 개선
- Git tag 생성/푸시 실패 시 에러 처리 추가
- Secret 파일 주입 시 디렉토리 생성 및 쓰기 실패 처리

* ci: 단계별 로그 메시지 추가 및 불필요한 로직 제거

* fix: 아티팩트 업로드 경로 수정

- Archive JAR Artifact 단계의 경로를 절대 경로로 수정
- working-directory 설정이 uses 액션에 적용되지 않는 문제 해결

* fix: CI 아티팩트 전파 지연 대응

- workflow_run 트리거에서 아티팩트 조회 지연으로 download 실패하는 문제 방지
- 다운로드 전 아티팩트 존재 여부를 폴링 후 진행

* fix: 아티팩트 다운로드 전파 지연 대응 (로직 변경)

- workflow_run 트리거에서 간헐적으로 Artifact not found 발생하는 문제 대응
- actions/download-artifact 대신 gh run download + 재시도 로직 적용

* docs: PR 템플릿 추가

* feat: JWT 인증/인가 및 내정보 조회 API 추가 (#17)

* feat: 회원 조회 관련 기능 추

* feat: 마스터 테이블 조회 기능 추가
- 직무, 경력은 테이블 전체 조회
- 기술은 파라미터에 따라 조건 검

* chore: cors, prod 설정

* chore: jwt 관련 의존성 및 yml 설정

* fix: EnableConfigurationProperties Config설정

* feat: refreshtoken 도메인 추가

* feat: Auth Dto 추가

* feat: feat: JWT 인증 필터 및 보안 설정 #13

* feat: RTR 기반 토큰 재발급 및 로그인 응답 토큰 포

* feat: 개발 토큰 발급 API 추가

* feat: 내 정보 조회 API 및 응답 DTO 추가

* feat: Swagger 보안 스키마 및 sprigdoc 설정 추가

* chore: cors 도메인 정리

* fix: conflict fix

* fix: CI job별 브랜치 checkout 설정 수정

* fix: SecurityConfig, prod-swagger설정 수정 (#19)

* fix: CD 헬스체크 URL을 실제 서비스 도메인으로 변경

* fix: prod-Swagger config 수정 (#20)

* fix: SecurityConfig, prod-swagger설정 수정

* fix: prod-swagger설정 수정

* chore: CD 헬스체크 재시도 횟수 조정

- 총 대기 시간: 15초 초기 대기 + 5회 × 5초 = 40초

* Update issue templates

* remove: Pull Request 템플릿 삭제

- 레포지토리 Settings에서 설정하여 템플릿 재생성

* fix: Security 수정 (#21)

* fix: SecurityConfig, prod-swagger설정 수정

* fix: prod-swagger설정 수정

* fix: SecurityConfig 수정

* fix: Security Config 수정 2 (#22)

* fix: SecurityConfig, prod-swagger설정 수정

* fix: prod-swagger설정 수정

* fix: SecurityConfig 수정

* fix: SecurityConfig 수정 - 2

* fix: api controller url (#23)

* fix: SecurityConfig, prod-swagger설정 수정

* fix: prod-swagger설정 수정

* fix: SecurityConfig 수정

* fix: SecurityConfig 수정 - 2

* fix: api 경로 제거

* fix: api 경로 원복 및 yml 수정 (#24)

* fix: SecurityConfig, prod-swagger설정 수정

* fix: prod-swagger설정 수정

* fix: SecurityConfig 수정

* fix: SecurityConfig 수정 - 2

* fix: api 경로 제거

* fix: api 경로 원복, yml 수

* fix: yml 원복 (#25)

* fix: SecurityConfig, prod-swagger설정 수정

* fix: prod-swagger설정 수정

* fix: SecurityConfig 수정

* fix: SecurityConfig 수정 - 2

* fix: api 경로 제거

* fix: api 경로 원복, yml 수

* fix: yml 원복

* fix: context-path 설정 (#26)

* fix: SecurityConfig, prod-swagger설정 수정

* fix: prod-swagger설정 수정

* fix: SecurityConfig 수정

* fix: SecurityConfig 수정 - 2

* fix: api 경로 제거

* fix: api 경로 원복, yml 수

* fix: yml 원복

* fix: context-path 설정

* fix: conflict fix - 1

* fix: conflict fix - 2

* fix: conflict fix - 3

* fix: Security 전역 설정 및 prod-yml 원복 (#27)

* fix: SecurityConfig, prod-swagger설정 수정

* fix: prod-swagger설정 수정

* fix: SecurityConfig 수정

* fix: SecurityConfig 수정 - 2

* fix: api 경로 제거

* fix: api 경로 원복, yml 수

* fix: yml 원복

* fix: context-path 설정

* fix: Security 전역설정 및 prod 롤백

* fix: api 경로 원

* Feature/be 18/chat domain feature 2 (#28)

* fix: SecurityConfig, prod-swagger설정 수정

* fix: prod-swagger설정 수정

* fix: SecurityConfig 수정

* fix: SecurityConfig 수정 - 2

* fix: api 경로 제거

* fix: api 경로 원복, yml 수

* fix: yml 원복

* fix: context-path 설정

* fix: Security 전역설정 및 prod 롤백

* fix: api 경로 원

* fix: api 경로 수정

* fix: Swagger 경로수정 (#29)

* fix: SecurityConfig, prod-swagger설정 수정

* fix: prod-swagger설정 수정

* fix: SecurityConfig 수정

* fix: SecurityConfig 수정 - 2

* fix: api 경로 제거

* fix: api 경로 원복, yml 수

* fix: yml 원복

* fix: context-path 설정

* fix: Security 전역설정 및 prod 롤백

* fix: api 경로 원

* fix: api 경로 수정

* fix: api 경로 수정

* chore: docs api 경로 수정

- `api` prefix 추가

* fix: 수정 헬스체크 및 Swagger UI 경로 설정

- CD 워크플로우 헬스체크 경로를 /api/actuator/health → /actuator/health로 변경
- Swagger UI 설정 경로를 /api/v3/api-docs → /v3/api-docs로 변경
  - Caddy 라우팅 설정과 일치하도록 수정
  - Swagger UI 원격 설정 로드 오류 해결

* Update issue templates

* chore: 릴리즈 태그에 timestamp 추가

* chore: CI/CD 워크플로우 개선

- CD 수동 배포 기능 추가 (브랜치 선택)
- release job 성공 확인 로직 추가
- 환경 설정 동적 처리 (production/development)
- 배포 중복 실행 방지 (concurrency)
- 아티팩트 다운로드 로직 개선
- 배포 프로세스 최적화 및 에러 핸들링 강화

* fix: 아티팩트 업로드 검증 단계 경로 수정

- Verify Artifact Upload 단계에서 working-directory 설정에 맞춰 경로 수정
- refit-backend/build/libs/... -> build/libs/... (상대 경로로 변경)

* fix: 수동 release 실행 시 CD 자동 트리거되도록 수정

- workflow_dispatch로 CI 실행 시에도 CD가 자동으로 트리거되도록 조건 추가
- workflow_run.event == 'push' 조건에 'workflow_dispatch' 추가

* fix: release job이 PR 생성 시 실행되지 않도록 수정

- pull_request 조건 제거
- release는 main/develop에 push될 때 또는 PR 머지 시(push 이벤트)만 실행
- PR 머지 시 push 이벤트로 처리되므로 pull_request 조건 불필요

* chore: 헬스 체크 대기 시간 및 재시도 횟수 조정

- 애플리케이션 시작 대기 시간: 10초 → 15초
- 헬스 체크 재시도 횟수: 10회 → 5회
- 재시도 간격: 3초 유지

* [ISSUE - #18] 채팅 도메인 정의 및 기능 구현 + Swagger 오류 수정 (#30)

* fix: SecurityConfig, prod-swagger설정 수정

* fix: prod-swagger설정 수정

* fix: SecurityConfig 수정

* fix: SecurityConfig 수정 - 2

* fix: api 경로 제거

* fix: api 경로 원복, yml 수

* fix: yml 원복

* fix: context-path 설정

* fix: Security 전역설정 및 prod 롤백

* fix: api 경로 원

* fix: api 경로 수정

* fix: api 경로 수정

* fix: swagger prod 수정

* fix: swagger prod 수정

* fix: yml 로깅 추가

* chore: websocket 의존성 추가

* chore: websocket 의존성 추가

* feat: 채팅 도메인 엔티티 추가
- 채팅방/메시지 기본 모델 정의 + 상태/타입 enum
- 읽지 않은 메시지 계산용 시퀀스 필드 추가

* feat: 채팅 저장소 레이어 추가
- 채팅방/메시지 조회를 위한 기본/커서 쿼리 추가

* feat: 채팅 서비스 레이어 추가
- 채팅방 생성/조회/종료, 메시지 전송/읽음 처리 구현
- 시퀀스 증가 및 마지막 읽음 업데이트 포함

* feat: 채팅 컨트롤러 추가
- 채팅방 REST API + WebSocket 메시지 전송 핸들러 구성

* feat: 채팅 DTO 추가
- 채팅 요청/응답 DTO 및 Swagger Schema 정의
- 종료 요청 body, 커서 응답 구조 포함

* feat: 커서 페이지 DTO 추가
- 커서 기반 응답 구조 공통화

* fix: 채팅 validation 메시지 매핑 보완

* chore: Websocket 설정 및 Config추가

* docs: 웹소켓 스웨거 문서 추가

* feat: 채팅 테스트 페이지 추가

* feat: 채팅 식별자 chatId 통일
- ReadMessage validation 키를 chat_id_required로 통일
- 메시지 커서 조회 메서드 명/파라미터를 chatId 기준으로 변경

* fix: validation 에러 코드 세분화

* feat: DB 커넥션 확인 로그 및 일부 에러로그 수정

* feat: JwtUtil기능 추가

* feat: JwtUtil기능 추가

* docs: PR 템플릿 추가

* docs: PR 템플릿 추가

* [ISSUE - #31] 유저 검색 및 닉네임 중복 검사 API 구현 (#32)

* fix: SecurityConfig, prod-swagger설정 수정

* fix: prod-swagger설정 수정

* fix: SecurityConfig 수정

* fix: SecurityConfig 수정 - 2

* fix: api 경로 제거

* fix: api 경로 원복, yml 수

* fix: yml 원복

* fix: context-path 설정

* fix: Security 전역설정 및 prod 롤백

* fix: api 경로 원

* fix: api 경로 수정

* fix: api 경로 수정

* fix: swagger prod 수정

* fix: swagger prod 수정

* fix: yml 로깅 추가

* chore: websocket 의존성 추가

* chore: websocket 의존성 추가

* feat: 채팅 도메인 엔티티 추가
- 채팅방/메시지 기본 모델 정의 + 상태/타입 enum
- 읽지 않은 메시지 계산용 시퀀스 필드 추가

* feat: 채팅 저장소 레이어 추가
- 채팅방/메시지 조회를 위한 기본/커서 쿼리 추가

* feat: 채팅 서비스 레이어 추가
- 채팅방 생성/조회/종료, 메시지 전송/읽음 처리 구현
- 시퀀스 증가 및 마지막 읽음 업데이트 포함

* feat: 채팅 컨트롤러 추가
- 채팅방 REST API + WebSocket 메시지 전송 핸들러 구성

* feat: 채팅 DTO 추가
- 채팅 요청/응답 DTO 및 Swagger Schema 정의
- 종료 요청 body, 커서 응답 구조 포함

* feat: 커서 페이지 DTO 추가
- 커서 기반 응답 구조 공통화

* fix: 채팅 validation 메시지 매핑 보완

* chore: Websocket 설정 및 Config추가

* docs: 웹소켓 스웨거 문서 추가

* feat: 채팅 테스트 페이지 추가

* feat: 채팅 식별자 chatId 통일
- ReadMessage validation 키를 chat_id_required로 통일
- 메시지 커서 조회 메서드 명/파라미터를 chatId 기준으로 변경

* fix: validation 에러 코드 세분화

* feat: DB 커넥션 확인 로그 및 일부 에러로그 수정

* feat: JwtUtil기능 추가

* feat: JwtUtil기능 추가

* feat: 유저 컨트롤러 닉네임 검사 및 검색 경로 정리
- 닉네임 중복 검사 API 추가 (/api/v1/users?nickname=...)
- 유저 검색 API를 /api/v1/users/search 로 분리
- Swagger optional 파라미터 example 제거

* feat: 닉네임 중복 검사 서비스 로직 추가

* feat: 닉네임 중복 검사 응답 DTO 추가

* feat: 유저 검색 기능 구현(현직자 검색 기능 미완성)

* fix: 요청 파라미터 검증 예외 처리 보완

* docs: 토큰 재발급 Swagger 예시 보완
- 201 응답 예시를 CREATED/token_refreshed로 수정

* docs: 스웨거 snake_case 수정

* docs: 스웨거 snake_case 수정

* docs: PR 템플릿 삭제

* docs: PR 템플릿 삭제

* chore: ci 빌드 단계 수정

- lint-and-test job에 Build Check 단계 추가 (bootJar)
- integration job에서 Build Verification 단계 제거
- PR 검증 시 빌드까지 확인하도록 변경

* [ISSUE - 18] dev용 static 파일 경로 수정 (#33)

* fix: SecurityConfig, prod-swagger설정 수정

* fix: prod-swagger설정 수정

* fix: SecurityConfig 수정

* fix: SecurityConfig 수정 - 2

* fix: api 경로 제거

* fix: api 경로 원복, yml 수

* fix: yml 원복

* fix: context-path 설정

* fix: Security 전역설정 및 prod 롤백

* fix: api 경로 원

* fix: api 경로 수정

* fix: api 경로 수정

* fix: swagger prod 수정

* fix: swagger prod 수정

* fix: yml 로깅 추가

* chore: websocket 의존성 추가

* chore: websocket 의존성 추가

* feat: 채팅 도메인 엔티티 추가
- 채팅방/메시지 기본 모델 정의 + 상태/타입 enum
- 읽지 않은 메시지 계산용 시퀀스 필드 추가

* feat: 채팅 저장소 레이어 추가
- 채팅방/메시지 조회를 위한 기본/커서 쿼리 추가

* feat: 채팅 서비스 레이어 추가
- 채팅방 생성/조회/종료, 메시지 전송/읽음 처리 구현
- 시퀀스 증가 및 마지막 읽음 업데이트 포함

* feat: 채팅 컨트롤러 추가
- 채팅방 REST API + WebSocket 메시지 전송 핸들러 구성

* feat: 채팅 DTO 추가
- 채팅 요청/응답 DTO 및 Swagger Schema 정의
- 종료 요청 body, 커서 응답 구조 포함

* feat: 커서 페이지 DTO 추가
- 커서 기반 응답 구조 공통화

* fix: 채팅 validation 메시지 매핑 보완

* chore: Websocket 설정 및 Config추가

* docs: 웹소켓 스웨거 문서 추가

* feat: 채팅 테스트 페이지 추가

* feat: 채팅 식별자 chatId 통일
- ReadMessage validation 키를 chat_id_required로 통일
- 메시지 커서 조회 메서드 명/파라미터를 chatId 기준으로 변경

* fix: validation 에러 코드 세분화

* feat: DB 커넥션 확인 로그 및 일부 에러로그 수정

* feat: JwtUtil기능 추가

* feat: JwtUtil기능 추가

* feat: 유저 컨트롤러 닉네임 검사 및 검색 경로 정리
- 닉네임 중복 검사 API 추가 (/api/v1/users?nickname=...)
- 유저 검색 API를 /api/v1/users/search 로 분리
- Swagger optional 파라미터 example 제거

* feat: 닉네임 중복 검사 서비스 로직 추가

* feat: 닉네임 중복 검사 응답 DTO 추가

* feat: 유저 검색 기능 구현(현직자 검색 기능 미완성)

* fix: 요청 파라미터 검증 예외 처리 보완

* docs: 토큰 재발급 Swagger 예시 보완
- 201 응답 예시를 CREATED/token_refreshed로 수정

* docs: 스웨거 snake_case 수정

* docs: 스웨거 snake_case 수정

* docs: dev용 html 경로 수정

* [ISSUE - 18] Security 경로 설정으로 인한 Filter 오류 수정 (#34)

* fix: SecurityConfig, prod-swagger설정 수정

* fix: prod-swagger설정 수정

* fix: SecurityConfig 수정

* fix: SecurityConfig 수정 - 2

* fix: api 경로 제거

* fix: api 경로 원복, yml 수

* fix: yml 원복

* fix: context-path 설정

* fix: Security 전역설정 및 prod 롤백

* fix: api 경로 원

* fix: api 경로 수정

* fix: api 경로 수정

* fix: swagger prod 수정

* fix: swagger prod 수정

* fix: yml 로깅 추가

* chore: websocket 의존성 추가

* chore: websocket 의존성 추가

* feat: 채팅 도메인 엔티티 추가
- 채팅방/메시지 기본 모델 정의 + 상태/타입 enum
- 읽지 않은 메시지 계산용 시퀀스 필드 추가

* feat: 채팅 저장소 레이어 추가
- 채팅방/메시지 조회를 위한 기본/커서 쿼리 추가

* feat: 채팅 서비스 레이어 추가
- 채팅방 생성/조회/종료, 메시지 전송/읽음 처리 구현
- 시퀀스 증가 및 마지막 읽음 업데이트 포함

* feat: 채팅 컨트롤러 추가
- 채팅방 REST API + WebSocket 메시지 전송 핸들러 구성

* feat: 채팅 DTO 추가
- 채팅 요청/응답 DTO 및 Swagger Schema 정의
- 종료 요청 body, 커서 응답 구조 포함

* feat: 커서 페이지 DTO 추가
- 커서 기반 응답 구조 공통화

* fix: 채팅 validation 메시지 매핑 보완

* chore: Websocket 설정 및 Config추가

* docs: 웹소켓 스웨거 문서 추가

* feat: 채팅 테스트 페이지 추가

* feat: 채팅 식별자 chatId 통일
- ReadMessage validation 키를 chat_id_required로 통일
- 메시지 커서 조회 메서드 명/파라미터를 chatId 기준으로 변경

* fix: validation 에러 코드 세분화

* feat: DB 커넥션 확인 로그 및 일부 에러로그 수정

* feat: JwtUtil기능 추가

* feat: JwtUtil기능 추가

* feat: 유저 컨트롤러 닉네임 검사 및 검색 경로 정리
- 닉네임 중복 검사 API 추가 (/api/v1/users?nickname=...)
- 유저 검색 API를 /api/v1/users/search 로 분리
- Swagger optional 파라미터 example 제거

* feat: 닉네임 중복 검사 서비스 로직 추가

* feat: 닉네임 중복 검사 응답 DTO 추가

* feat: 유저 검색 기능 구현(현직자 검색 기능 미완성)

* fix: 요청 파라미터 검증 예외 처리 보완

* docs: 토큰 재발급 Swagger 예시 보완
- 201 응답 예시를 CREATED/token_refreshed로 수정

* docs: 스웨거 snake_case 수정

* docs: 스웨거 snake_case 수정

* docs: dev용 html 경로 수정

* fix: Security 인증 경로 수정

* fix: PM2 명령어 EPIPE 에러 처리

- PM2 명령어 실행 시 발생하는 EPIPE 에러 무시
- stderr를 /dev/null로 리다이렉트하여 에러 메시지 숨김
- 실제 작업은 성공하지만 PM2 데몬 통신 중 발생하는 에러 처리

* [ISSUE - 18] dev용 static 파일 수정 (#35)

* fix: SecurityConfig, prod-swagger설정 수정

* fix: prod-swagger설정 수정

* fix: SecurityConfig 수정

* fix: SecurityConfig 수정 - 2

* fix: api 경로 제거

* fix: api 경로 원복, yml 수

* fix: yml 원복

* fix: context-path 설정

* fix: Security 전역설정 및 prod 롤백

* fix: api 경로 원

* fix: api 경로 수정

* fix: api 경로 수정

* fix: swagger prod 수정

* fix: swagger prod 수정

* fix: yml 로깅 추가

* chore: websocket 의존성 추가

* chore: websocket 의존성 추가

* feat: 채팅 도메인 엔티티 추가
- 채팅방/메시지 기본 모델 정의 + 상태/타입 enum
- 읽지 않은 메시지 계산용 시퀀스 필드 추가

* feat: 채팅 저장소 레이어 추가
- 채팅방/메시지 조회를 위한 기본/커서 쿼리 추가

* feat: 채팅 서비스 레이어 추가
- 채팅방 생성/조회/종료, 메시지 전송/읽음 처리 구현
- 시퀀스 증가 및 마지막 읽음 업데이트 포함

* feat: 채팅 컨트롤러 추가
- 채팅방 REST API + WebSocket 메시지 전송 핸들러 구성

* feat: 채팅 DTO 추가
- 채팅 요청/응답 DTO 및 Swagger Schema 정의
- 종료 요청 body, 커서 응답 구조 포함

* feat: 커서 페이지 DTO 추가
- 커서 기반 응답 구조 공통화

* fix: 채팅 validation 메시지 매핑 보완

* chore: Websocket 설정 및 Config추가

* docs: 웹소켓 스웨거 문서 추가

* feat: 채팅 테스트 페이지 추가

* feat: 채팅 식별자 chatId 통일
- ReadMessage validation 키를 chat_id_required로 통일
- 메시지 커서 조회 메서드 명/파라미터를 chatId 기준으로 변경

* fix: validation 에러 코드 세분화

* feat: DB 커넥션 확인 로그 및 일부 에러로그 수정

* feat: JwtUtil기능 추가

* feat: JwtUtil기능 추가

* feat: 유저 컨트롤러 닉네임 검사 및 검색 경로 정리
- 닉네임 중복 검사 API 추가 (/api/v1/users?nickname=...)
- 유저 검색 API를 /api/v1/users/search 로 분리
- Swagger optional 파라미터 example 제거

* feat: 닉네임 중복 검사 서비스 로직 추가

* feat: 닉네임 중복 검사 응답 DTO 추가

* feat: 유저 검색 기능 구현(현직자 검색 기능 미완성)

* fix: 요청 파라미터 검증 예외 처리 보완

* docs: 토큰 재발급 Swagger 예시 보완
- 201 응답 예시를 CREATED/token_refreshed로 수정

* docs: 스웨거 snake_case 수정

* docs: 스웨거 snake_case 수정

* docs: dev용 html 경로 수정

* fix: Security 인증 경로 수정

* test: 배포환경 ws 경로 수정

* [ISSUE - 18] 웹소켓 연결 인증 수정 (#36)

* fix: SecurityConfig, prod-swagger설정 수정

* fix: prod-swagger설정 수정

* fix: SecurityConfig 수정

* fix: SecurityConfig 수정 - 2

* fix: api 경로 제거

* fix: api 경로 원복, yml 수

* fix: yml 원복

* fix: context-path 설정

* fix: Security 전역설정 및 prod 롤백

* fix: api 경로 원

* fix: api 경로 수정

* fix: api 경로 수정

* fix: swagger prod 수정

* fix: swagger prod 수정

* fix: yml 로깅 추가

* chore: websocket 의존성 추가

* chore: websocket 의존성 추가

* feat: 채팅 도메인 엔티티 추가
- 채팅방/메시지 기본 모델 정의 + 상태/타입 enum
- 읽지 않은 메시지 계산용 시퀀스 필드 추가

* feat: 채팅 저장소 레이어 추가
- 채팅방/메시지 조회를 위한 기본/커서 쿼리 추가

* feat: 채팅 서비스 레이어 추가
- 채팅방 생성/조회/종료, 메시지 전송/읽음 처리 구현
- 시퀀스 증가 및 마지막 읽음 업데이트 포함

* feat: 채팅 컨트롤러 추가
- 채팅방 REST API + WebSocket 메시지 전송 핸들러 구성

* feat: 채팅 DTO 추가
- 채팅 요청/응답 DTO 및 Swagger Schema 정의
- 종료 요청 body, 커서 응답 구조 포함

* feat: 커서 페이지 DTO 추가
- 커서 기반 응답 구조 공통화

* fix: 채팅 validation 메시지 매핑 보완

* chore: Websocket 설정 및 Config추가

* docs: 웹소켓 스웨거 문서 추가

* feat: 채팅 테스트 페이지 추가

* feat: 채팅 식별자 chatId 통일
- ReadMessage validation 키를 chat_id_required로 통일
- 메시지 커서 조회 메서드 명/파라미터를 chatId 기준으로 변경

* fix: validation 에러 코드 세분화

* feat: DB 커넥션 확인 로그 및 일부 에러로그 수정

* feat: JwtUtil기능 추가

* feat: JwtUtil기능 추가

* feat: 유저 컨트롤러 닉네임 검사 및 검색 경로 정리
- 닉네임 중복 검사 API 추가 (/api/v1/users?nickname=...)
- 유저 검색 API를 /api/v1/users/search 로 분리
- Swagger optional 파라미터 example 제거

* feat: 닉네임 중복 검사 서비스 로직 추가

* feat: 닉네임 중복 검사 응답 DTO 추가

* feat: 유저 검색 기능 구현(현직자 검색 기능 미완성)

* fix: 요청 파라미터 검증 예외 처리 보완

* docs: 토큰 재발급 Swagger 예시 보완
- 201 응답 예시를 CREATED/token_refreshed로 수정

* docs: 스웨거 snake_case 수정

* docs: 스웨거 snake_case 수정

* docs: dev용 html 경로 수정

* fix: Security 인증 경로 수정

* test: 배포환경 ws 경로 수정

* fix: 웹소켓 연결 인증 설정 수정

* [ISSUE - 18] 웹소켓 연결 설정 수정 (#37)

* fix: SecurityConfig, prod-swagger설정 수정

* fix: prod-swagger설정 수정

* fix: SecurityConfig 수정

* fix: SecurityConfig 수정 - 2

* fix: api 경로 제거

* fix: api 경로 원복, yml 수

* fix: yml 원복

* fix: context-path 설정

* fix: Security 전역설정 및 prod 롤백

* fix: api 경로 원

* fix: api 경로 수정

* fix: api 경로 수정

* fix: swagger prod 수정

* fix: swagger prod 수정

* fix: yml 로깅 추가

* chore: websocket 의존성 추가

* chore: websocket 의존성 추가

* feat: 채팅 도메인 엔티티 추가
- 채팅방/메시지 기본 모델 정의 + 상태/타입 enum
- 읽지 않은 메시지 계산용 시퀀스 필드 추가

* feat: 채팅 저장소 레이어 추가
- 채팅방/메시지 조회를 위한 기본/커서 쿼리 추가

* feat: 채팅 서비스 레이어 추가
- 채팅방 생성/조회/종료, 메시지 전송/읽음 처리 구현
- 시퀀스 증가 및 마지막 읽음 업데이트 포함

* feat: 채팅 컨트롤러 추가
- 채팅방 REST API + WebSocket 메시지 전송 핸들러 구성

* feat: 채팅 DTO 추가
- 채팅 요청/응답 DTO 및 Swagger Schema 정의
- 종료 요청 body, 커서 응답 구조 포함

* feat: 커서 페이지 DTO 추가
- 커서 기반 응답 구조 공통화

* fix: 채팅 validation 메시지 매핑 보완

* chore: Websocket 설정 및 Config추가

* docs: 웹소켓 스웨거 문서 추가

* feat: 채팅 테스트 페이지 추가

* feat: 채팅 식별자 chatId 통일
- ReadMessage validation 키를 chat_id_required로 통일
- 메시지 커서 조회 메서드 명/파라미터를 chatId 기준으로 변경

* fix: validation 에러 코드 세분화

* feat: DB 커넥션 확인 로그 및 일부 에러로그 수정

* feat: JwtUtil기능 추가

* feat: JwtUtil기능 추가

* feat: 유저 컨트롤러 닉네임 검사 및 검색 경로 정리
- 닉네임 중복 검사 API 추가 (/api/v1/users?nickname=...)
- 유저 검색 API를 /api/v1/users/search 로 분리
- Swagger optional 파라미터 example 제거

* feat: 닉네임 중복 검사 서비스 로직 추가

* feat: 닉네임 중복 검사 응답 DTO 추가

* feat: 유저 검색 기능 구현(현직자 검색 기능 미완성)

* fix: 요청 파라미터 검증 예외 처리 보완

* docs: 토큰 재발급 Swagger 예시 보완
- 201 응답 예시를 CREATED/token_refreshed로 수정

* docs: 스웨거 snake_case 수정

* docs: 스웨거 snake_case 수정

* docs: dev용 html 경로 수정

* fix: Security 인증 경로 수정

* test: 배포환경 ws 경로 수정

* fix: 웹소켓 연결 인증 설정 수정

* fix: 웹소켓 연결 설정 수정

* [ISSUE - 18] test 페이지 페이로드 수정 (#38)

* fix: SecurityConfig, prod-swagger설정 수정

* fix: prod-swagger설정 수정

* fix: SecurityConfig 수정

* fix: SecurityConfig 수정 - 2

* fix: api 경로 제거

* fix: api 경로 원복, yml 수

* fix: yml 원복

* fix: context-path 설정

* fix: Security 전역설정 및 prod 롤백

* fix: api 경로 원

* fix: api 경로 수정

* fix: api 경로 수정

* fix: swagger prod 수정

* fix: swagger prod 수정

* fix: yml 로깅 추가

* chore: websocket 의존성 추가

* chore: websocket 의존성 추가

* feat: 채팅 도메인 엔티티 추가
- 채팅방/메시지 기본 모델 정의 + 상태/타입 enum
- 읽지 않은 메시지 계산용 시퀀스 필드 추가

* feat: 채팅 저장소 레이어 추가
- 채팅방/메시지 조회를 위한 기본/커서 쿼리 추가

* feat: 채팅 서비스 레이어 추가
- 채팅방 생성/조회/종료, 메시지 전송/읽음 처리 구현
- 시퀀스 증가 및 마지막 읽음 업데이트 포함

* feat: 채팅 컨트롤러 추가
- 채팅방 REST API + WebSocket 메시지 전송 핸들러 구성

* feat: 채팅 DTO 추가
- 채팅 요청/응답 DTO 및 Swagger Schema 정의
- 종료 요청 body, 커서 응답 구조 포함

* feat: 커서 페이지 DTO 추가
- 커서 기반 응답 구조 공통화

* fix: 채팅 validation 메시지 매핑 보완

* chore: Websocket 설정 및 Config추가

* docs: 웹소켓 스웨거 문서 추가

* feat: 채팅 테스트 페이지 추가

* feat: 채팅 식별자 chatId 통일
- ReadMessage validation 키를 chat_id_required로 통일
- 메시지 커서 조회 메서드 명/파라미터를 chatId 기준으로 변경

* fix: validation 에러 코드 세분화

* feat: DB 커넥션 확인 로그 및 일부 에러로그 수정

* feat: JwtUtil기능 추가

* feat: JwtUtil기능 추가

* feat: 유저 컨트롤러 닉네임 검사 및 검색 경로 정리
- 닉네임 중복 검사 API 추가 (/api/v1/users?nickname=...)
- 유저 검색 API를 /api/v1/users/search 로 분리
- Swagger optional 파라미터 example 제거

* feat: 닉네임 중복 검사 서비스 로직 추가

* feat: 닉네임 중복 검사 응답 DTO 추가

* feat: 유저 검색 기능 구현(현직자 검색 기능 미완성)

* fix: 요청 파라미터 검증 예외 처리 보완

* docs: 토큰 재발급 Swagger 예시 보완
- 201 응답 예시를 CREATED/token_refreshed로 수정

* docs: 스웨거 snake_case 수정

* docs: 스웨거 snake_case 수정

* docs: dev용 html 경로 수정

* fix: Security 인증 경로 수정

* test: 배포환경 ws 경로 수정

* fix: 웹소켓 연결 인증 설정 수정

* fix: 웹소켓 연결 설정 수정

* [ISSUE - 18] test 페이지 페이로드 수정 - 2 (#39)

* fix: SecurityConfig, prod-swagger설정 수정

* fix: prod-swagger설정 수정

* fix: SecurityConfig 수정

* fix: SecurityConfig 수정 - 2

* fix: api 경로 제거

* fix: api 경로 원복, yml 수

* fix: yml 원복

* fix: context-path 설정

* fix: Security 전역설정 및 prod 롤백

* fix: api 경로 원

* fix: api 경로 수정

* fix: api 경로 수정

* fix: swagger prod 수정

* fix: swagger prod 수정

* fix: yml 로깅 추가

* chore: websocket 의존성 추가

* chore: websocket 의존성 추가

* feat: 채팅 도메인 엔티티 추가
- 채팅방/메시지 기본 모델 정의 + 상태/타입 enum
- 읽지 않은 메시지 계산용 시퀀스 필드 추가

* feat: 채팅 저장소 레이어 추가
- 채팅방/메시지 조회를 위한 기본/커서 쿼리 추가

* feat: 채팅 서비스 레이어 추가
- 채팅방 생성/조회/종료, 메시지 전송/읽음 처리 구현
- 시퀀스 증가 및 마지막 읽음 업데이트 포함

* feat: 채팅 컨트롤러 추가
- 채팅방 REST API + WebSocket 메시지 전송 핸들러 구성

* feat: 채팅 DTO 추가
- 채팅 요청/응답 DTO 및 Swagger Schema 정의
- 종료 요청 body, 커서 응답 구조 포함

* feat: 커서 페이지 DTO 추가
- 커서 기반 응답 구조 공통화

* fix: 채팅 validation 메시지 매핑 보완

* chore: Websocket 설정 및 Config추가

* docs: 웹소켓 스웨거 문서 추가

* feat: 채팅 테스트 페이지 추가

* feat: 채팅 식별자 chatId 통일
- ReadMessage validation 키를 chat_id_required로 통일
- 메시지 커서 조회 메서드 명/파라미터를 chatId 기준으로 변경

* fix: validation 에러 코드 세분화

* feat: DB 커넥션 확인 로그 및 일부 에러로그 수정

* feat: JwtUtil기능 추가

* feat: JwtUtil기능 추가

* feat: 유저 컨트롤러 닉네임 검사 및 검색 경로 정리
- 닉네임 중복 검사 API 추가 (/api/v1/users?nickname=...)
- 유저 검색 API를 /api/v1/users/search 로 분리
- Swagger optional 파라미터 example 제거

* feat: 닉네임 중복 검사 서비스 로직 추가

* feat: 닉네임 중복 검사 응답 DTO 추가

* feat: 유저 검색 기능 구현(현직자 검색 기능 미완성)

* fix: 요청 파라미터 검증 예외 처리 보완

* docs: 토큰 재발급 Swagger 예시 보완
- 201 응답 예시를 CREATED/token_refreshed로 수정

* docs: 스웨거 snake_case 수정

* docs: 스웨거 snake_case 수정

* docs: dev용 html 경로 수정

* fix: Security 인증 경로 수정

* test: 배포환경 ws 경로 수정

* fix: 웹소켓 연결 인증 설정 수정

* fix: 웹소켓 연결 설정 수정

* fix: 페이로드 room_id를 chat_id로 변경

* [ISSUE - 18] ChatRes 응닶값 id -> chat_id로 수정 (#40)

* fix: SecurityConfig, prod-swagger설정 수정

* fix: prod-swagger설정 수정

* fix: SecurityConfig 수정

* fix: SecurityConfig 수정 - 2

* fix: api 경로 제거

* fix: api 경로 원복, yml 수

* fix: yml 원복

* fix: context-path 설정

* fix: Security 전역설정 및 prod 롤백

* fix: api 경로 원

* fix: api 경로 수정

* fix: api 경로 수정

* fix: swagger prod 수정

* fix: swagger prod 수정

* fix: yml 로깅 추가

* chore: websocket 의존성 추가

* chore: websocket 의존성 추가

* feat: 채팅 도메인 엔티티 추가
- 채팅방/메시지 기본 모델 정의 + 상태/타입 enum
- 읽지 않은 메시지 계산용 시퀀스 필드 추가

* feat: 채팅 저장소 레이어 추가
- 채팅방/메시지 조회를 위한 기본/커서 쿼리 추가

* feat: 채팅 서비스 레이어 추가
- 채팅방 생성/조회/종료, 메시지 전송/읽음 처리 구현
- 시퀀스 증가 및 마지막 읽음 업데이트 포함

* feat: 채팅 컨트롤러 추가
- 채팅방 REST API + WebSocket 메시지 전송 핸들러 구성

* feat: 채팅 DTO 추가
- 채팅 요청/응답 DTO 및 Swagger Schema 정의
- 종료 요청 body, 커서 응답 구조 포함

* feat: 커서 페이지 DTO 추가
- 커서 기반 응답 구조 공통화

* fix: 채팅 validation 메시지 매핑 보완

* chore: Websocket 설정 및 Config추가

* docs: 웹소켓 스웨거 문서 추가

* feat: 채팅 테스트 페이지 추가

* feat: 채팅 식별자 chatId 통일
- ReadMessage validation 키를 chat_id_required로 통일
- 메시지 커서 조회 메서드 명/파라미터를 chatId 기준으로 변경

* fix: validation 에러 코드 세분화

* feat: DB 커넥션 확인 로그 및 일부 에러로그 수정

* feat: JwtUtil기능 추가

* feat: JwtUtil기능 추가

* feat: 유저 컨트롤러 닉네임 검사 및 검색 경로 정리
- 닉네임 중복 검사 API 추가 (/api/v1/users?nickname=...)
- 유저 검색 API를 /api/v1/users/search 로 분리
- Swagger optional 파라미터 example 제거

* feat: 닉네임 중복 검사 서비스 로직 추가

* feat: 닉네임 중복 검사 응답 DTO 추가

* feat: 유저 검색 기능 구현(현직자 검색 기능 미완성)

* fix: 요청 파라미터 검증 예외 처리 보완

* docs: 토큰 재발급 Swagger 예시 보완
- 201 응답 예시를 CREATED/token_refreshed로 수정

* docs: 스웨거 snake_case 수정

* docs: 스웨거 snake_case 수정

* docs: dev용 html 경로 수정

* fix: Security 인증 경로 수정

* test: 배포환경 ws 경로 수정

* fix: 웹소켓 연결 인증 설정 수정

* fix: 웹소켓 연결 설정 수정

* fix: 페이로드 room_id를 chat_id로 변경

* fix: 페이로드 id를 chat_id로 변경

* [ISSUE - 18] 직렬화 수정 (#41)

* fix: SecurityConfig, prod-swagger설정 수정

* fix: prod-swagger설정 수정

* fix: SecurityConfig 수정

* fix: SecurityConfig 수정 - 2

* fix: api 경로 제거

* fix: api 경로 원복, yml 수

* fix: yml 원복

* fix: context-path 설정

* fix: Security 전역설정 및 prod 롤백

* fix: api 경로 원

* fix: api 경로 수정

* fix: api 경로 수정

* fix: swagger prod 수정

* fix: swagger prod 수정

* fix: yml 로깅 추가

* chore: websocket 의존성 추가

* chore: websocket 의존성 추가

* feat: 채팅 도메인 엔티티 추가
- 채팅방/메시지 기본 모델 정의 + 상태/타입 enum
- 읽지 않은 메시지 계산용 시퀀스 필드 추가

* feat: 채팅 저장소 레이어 추가
- 채팅방/메시지 조회를 위한 기본/커서 쿼리 추가

* feat: 채팅 서비스 레이어 추가
- 채팅방 생성/조회/종료, 메시지 전송/읽음 처리 구현
- 시퀀스 증가 및 마지막 읽음 업데이트 포함

* feat: 채팅 컨트롤러 추가
- 채팅방 REST API + WebSocket 메시지 전송 핸들러 구성

* feat: 채팅 DTO 추가
- 채팅 요청/응답 DTO 및 Swagger Schema 정의
- 종료 요청 body, 커서 응답 구조 포함

* feat: 커서 페이지 DTO 추가
- 커서 기반 응답 구조 공통화

* fix: 채팅 validation 메시지 매핑 보완

* chore: Websocket 설정 및 Config추가

* docs: 웹소켓 스웨거 문서 추가

* feat: 채팅 테스트 페이지 추가

* feat: 채팅 식별자 chatId 통일
- ReadMessage validation 키를 chat_id_required로 통일
- 메시지 커서 조회 메서드 명/파라미터를 chatId 기준으로 변경

* fix: validation 에러 코드 세분화

* feat: DB 커넥션 확인 로그 및 일부 에러로그 수정

* feat: JwtUtil기능 추가

* feat: JwtUtil기능 추가

* feat: 유저 컨트롤러 닉네임 검사 및 검색 경로 정리
- 닉네임 중복 검사 API 추가 (/api/v1/users?nickname=...)
- 유저 검색 API를 /api/v1/users/search 로 분리
- Swagger optional 파라미터 example 제거

* feat: 닉네임 중복 검사 서비스 로직 추가

* feat: 닉네임 중복 검사 응답 DTO 추가

* feat: 유저 검색 기능 구현(현직자 검색 기능 미완성)

* fix: 요청 파라미터 검증 예외 처리 보완

* docs: 토큰 재발급 Swagger 예시 보완
- 201 응답 예시를 CREATED/token_refreshed로 수정

* docs: 스웨거 snake_case 수정

* docs: 스웨거 snake_case 수정

* docs: dev용 html 경로 수정

* fix: Security 인증 경로 수정

* test: 배포환경 ws 경로 수정

* fix: 웹소켓 연결 인증 설정 수정

* fix: 웹소켓 연결 설정 수정

* fix: 페이로드 room_id를 chat_id로 변경

* fix: 페이로드 id를 chat_id로 변경

* fix: chat_id 직렬화 수

* [ISSUE - 18] SecurityConfig 수정 (#42)

* fix: SecurityConfig, prod-swagger설정 수정

* fix: prod-swagger설정 수정

* fix: SecurityConfig 수정

* fix: SecurityConfig 수정 - 2

* fix: api 경로 제거

* fix: api 경로 원복, yml 수

* fix: yml 원복

* fix: context-path 설정

* fix: Security 전역설정 및 prod 롤백

* fix: api 경로 원

* fix: api 경로 수정

* fix: api 경로 수정

* fix: swagger prod 수정

* fix: swagger prod 수정

* fix: yml 로깅 추가

* chore: websocket 의존성 추가

* chore: websocket 의존성 추가

* feat: 채팅 도메인 엔티티 추가
- 채팅방/메시지 기본 모델 정의 + 상태/타입 enum
- 읽지 않은 메시지 계산용 시퀀스 필드 추가

* feat: 채팅 저장소 레이어 추가
- 채팅방/메시지 조회를 위한 기본/커서 쿼리 추가

* feat: 채팅 서비스 레이어 추가
- 채팅방 생성/조회/종료, 메시지 전송/읽음 처리 구현
- 시퀀스 증가 및 마지막 읽음 업데이트 포함

* feat: 채팅 컨트롤러 추가
- 채팅방 REST API + WebSocket 메시지 전송 핸들러 구성

* feat: 채팅 DTO 추가
- 채팅 요청/응답 DTO 및 Swagger Schema 정의
- 종료 요청 body, 커서 응답 구조 포함

* feat: 커서 페이지 DTO 추가
- 커서 기반 응답 구조 공통화

* fix: 채팅 validation 메시지 매핑 보완

* chore: Websocket 설정 및 Config추가

* docs: 웹소켓 스웨거 문서 추가

* feat: 채팅 테스트 페이지 추가

* feat: 채팅 식별자 chatId 통일
- ReadMessage validation 키를 chat_id_required로 통일
- 메시지 커서 조회 메서드 명/파라미터를 chatId 기준으로 변경

* fix: validation 에러 코드 세분화

* feat: DB 커넥션 확인 로그 및 일부 에러로그 수정

* feat: JwtUtil기능 추가

* feat: JwtUtil기능 추가

* feat: 유저 컨트롤러 닉네임 검사 및 검색 경로 정리
- 닉네임 중복 검사 API 추가 (/api/v1/users?nickname=...)
- 유저 검색 API를 /api/v1/users/search 로 분리
- Swagger optional 파라미터 example 제거

* feat: 닉네임 중복 검사 서비스 로직 추가

* feat: 닉네임 중복 검사 응답 DTO 추가

* feat: 유저 검색 기능 구현(현직자 검색 기능 미완성)

* fix: 요청 파라미터 검증 예외 처리 보완

* docs: 토큰 재발급 Swagger 예시 보완
- 201 응답 예시를 CREATED/token_refreshed로 수정

* docs: 스웨거 snake_case 수정

* docs: 스웨거 snake_case 수정

* docs: dev용 html 경로 수정

* fix: Security 인증 경로 수정

* test: 배포환경 ws 경로 수정

* fix: 웹소켓 연결 인증 설정 수정

* fix: 웹소켓 연결 설정 수정

* fix: 페이로드 room_id를 chat_id로 변경

* fix: 페이로드 id를 chat_id로 변경

* fix: chat_id 직렬화 수

* fix: SecurityConfig 경로 추가

* [ISSUE - 43] 현직자 테이블 정의 및 검색 기능 구현 (#44)

* feat: 현직자 프로플 엔티티 추가

* feat: 현직자 전용 레포지토리 추가
- Expert Repo: 검색/상세 조회 쿼리 전용
- ExpertProfile Repo: CRUD 전

* feat: 현직자 응답 DTO 추가

* feat: 현직자 조회 서비스 추가
- 커서 기반 검색 + 상세 조회
- 직무/스킬 매핑

* feat: 현직자 조회 API 컨트롤러 추가
- 현직자 검색 permitAll

* feat: 현직자 검색 쿼리 분리
- 현직자 검색 쿼리 제거

* feat: 개발용 유저 타입 전환 API 추가
- 이메일 인증 API 개발 전 구직자 -> 현직자 임시기능

* feat: 현직자 예외타입 추가

* feat: 현직자 회원가입 시 현직자 프로필 생성

* feat: 스킬 스키마 스웨거 보완

* feat: 직무/스킬 조회 보완

* [ISSUE - 43] Stirng lower 캐스팅 에러 개선 (#45)

* feat: 현직자 프로플 엔티티 추가

* feat: 현직자 전용 레포지토리 추가
- Expert Repo: 검색/상세 조회 쿼리 전용
- ExpertProfile Repo: CRUD 전

* feat: 현직자 응답 DTO 추가

* feat: 현직자 조회 서비스 추가
- 커서 기반 검색 + 상세 조회
- 직무/스킬 매핑

* feat: 현직자 조회 API 컨트롤러 추가
- 현직자 검색 permitAll

* feat: 현직자 검색 쿼리 분리
- 현직자 검색 쿼리 제거

* feat: 개발용 유저 타입 전환 API 추가
- 이메일 인증 API 개발 전 구직자 -> 현직자 임시기능

* feat: 현직자 예외타입 추가

* feat: 현직자 회원가입 시 현직자 프로필 생성

* feat: 스킬 스키마 스웨거 보완

* feat: 직무/스킬 조회 보완

* fix: Stirng lower 캐스팅 에러 개선

* [ISSUE - 43] Stirng lower 캐스팅 에러 개선 (#46)

* feat: 현직자 프로플 엔티티 추가

* feat: 현직자 전용 레포지토리 추가
- Expert Repo: 검색/상세 조회 쿼리 전용
- ExpertProfile Repo: CRUD 전

* feat: 현직자 응답 DTO 추가

* feat: 현직자 조회 서비스 추가
- 커서 기반 검색 + 상세 조회
- 직무/스킬 매핑

* feat: 현직자 조회 API 컨트롤러 추가
- 현직자 검색 permitAll

* feat: 현직자 검색 쿼리 분리
- 현직자 검색 쿼리 제거

* feat: 개발용 유저 타입 전환 API 추가
- 이메일 인증 API 개발 전 구직자 -> 현직자 임시기능

* feat: 현직자 예외타입 추가

* feat: 현직자 회원가입 시 현직자 프로필 생성

* feat: 스킬 스키마 스웨거 보완

* feat: 직무/스킬 조회 보완

* fix: Stirng lower 캐스팅 에러 개선

* fix: Stirng lower 캐스팅 에러 개선 - 2
- lower()대신 ILIKE 변

* [ISSUE - 43] Stirng lower 캐스팅 에러 개선 - 3 (#47)

* feat: 현직자 프로플 엔티티 추가

* feat: 현직자 전용 레포지토리 추가
- Expert Repo: 검색/상세 조회 쿼리 전용
- ExpertProfile Repo: CRUD 전

* feat: 현직자 응답 DTO 추가

* feat: 현직자 조회 서비스 추가
- 커서 기반 검색 + 상세 조회
- 직무/스킬 매핑

* feat: 현직자 조회 API 컨트롤러 추가
- 현직자 검색 permitAll

* feat: 현직자 검색 쿼리 분리
- 현직자 검색 쿼리 제거

* feat: 개발용 유저 타입 전환 API 추가
- 이메일 인증 API 개발 전 구직자 -> 현직자 임시기능

* feat: 현직자 예외타입 추가

* feat: 현직자 회원가입 시 현직자 프로필 생성

* feat: 스킬 스키마 스웨거 보완

* feat: 직무/스킬 조회 보완

* fix: Stirng lower 캐스팅 에러 개선

* fix: Stirng lower 캐스팅 에러 개선 - 2
- lower()대신 ILIKE 변

* fix: Stirng lower 캐스팅 에러 개선 - 3
- 파라미터 타입 text 캐스팅

* refactor: SSH/SCP → SSM/S3 배포 방식 전환

- 파일 전송: SCP → S3 업로드 후 EC2에서 다운로드
- 배포 실행: SSH 직접 접속 → SSM send-command
- 보안 강화: SSH 포트 공개 접근 불필요

* fix: base64 인코딩 부분에서 이스케이프 오류 수정

* fix: SSM parameters JSON 파싱 오류 수정 및 에러 처리 개선

* fix: workflow_dispatch 제거, CI 성공 후 자동 배포만 허용

* fix: PM2를 실행 계정 수정

* feat: discord web hook 추가

* [ISSUE - 48] 현직자 이메일 인증 구현 (#49)

* chore: 이메일 인증 관련 의존성 추가

* feat: 이메일 인증 엔티티/레포지토리 추

* feat: 이메일 인증 요청/응답 DTO 추가

* feat: 이메일 인증 서비스 로직 구현
- 5분 TTL, 10분당 3회 제한
- 코드 생성/재발송/검증 처리
- 무료 이메일 도메인/일회성 메일 차단

* feat: 이메일 인증 API 추가 (회원가입/마이페이지)

* feat: 이메일 인증 예외 코드/응답 확장
- 인증 관련 에러 코드 추가
- 에러 응답 data 포함 대응

* feat: 이메일 인증 공개 엔드포인트 허용

* feat: 회원가입 현직자 시 인증 연동
- expert_profile 생성
- email 인증 완료 시 verified = true

* feat: 회원가입 Swagger 요청 바인딩/예시 보완

* feat: 이메일 도메인 마스터 엔티티/레포 추가

* feat: 이메일 도메인 마스터 조회 API 추

* feat: dev 유저타입 전환로직 이메일 인증로직 추가

* chore: SMTP 환경 설정 추가

* [ISSUE - 48] 이메일 도메인 테이블명 수정 (#50)

* chore: 이메일 인증 관련 의존성 추가

* feat: 이메일 인증 엔티티/레포지토리 추

* feat: 이메일 인증 요청/응답 DTO 추가

* feat: 이메일 인증 서비스 로직 구현
- 5분 TTL, 10분당 3회 제한
- 코드 생성/재발송/검증 처리
- 무료 이메일 도메인/일회성 메일 차단

* feat: 이메일 인증 API 추가 (회원가입/마이페이지)

* feat: 이메일 인증 예외 코드/응답 확장
- 인증 관련 에러 코드 추가
- 에러 응답 data 포함 대응

* feat: 이메일 인증 공개 엔드포인트 허용

* feat: 회원가입 현직자 시 인증 연동
- expert_profile 생성
- email 인증 완료 시 verified = true

* feat: 회원가입 Swagger 요청 바인딩/예시 보완

* feat: 이메일 도메인 마스터 엔티티/레포 추가

* feat: 이메일 도메인 마스터 조회 API 추

* feat: dev 유저타입 전환로직 이메일 인증로직 추가

* chore: SMTP 환경 설정 추가

* fix: 테이블명 단수->복수 수정

* feat: 로컬 카카오 OAuth 분기 추가 및 dev 콜백 이동 경로 수 (#55)

* [ISSUE - 53] Swagger 명세 도메인 분리 및 공통 응답/에러 예시 자동화 (#56)

* feat: swagger 메타 어노테이션 확장 및 에러/요청 바디 커스터마이저 개

* feat: swagger spec 도메인 분리(auth/user/expert/master/chat)

* refactor: 컨트롤러에 spec 적

* [ISSUE - 57] CORS PATCH 추가 (#58)

* feat: swagger 메타 어노테이션 확장 및 에러/요청 바디 커스터마이저 개

* feat: swagger spec 도메인 분리(auth/user/expert/master/chat)

* refactor: 컨트롤러에 spec 적

* fix: CORS PATCH 추

* [ISSUE - 59] 이력서 도메인 CRUD 구현 (#60)

* feat: 이력서 엔티티/DTO 정의

* feat: 이력서 조회/생성/수정 서비스 및 리포지토리 추가

* feat: 이력서 CRUD API 컨트롤러 추가

* feat: 이력서 API Swagger 스펙 정의

* fix: JWT 필터 ObjectMapper 타입 정합성 수정

* feat: 이력서 검증 실패 메시지 매핑 추가

* [ISSUE - 52] 현직자 임베딩 업데이트 API 추가 (#61)

* feat: 현직자 임베딩 업데이트 API 추가

* feat: 임베딩/이력서 검증 에러코드 세분화

* feat: 현직자 임베딩 API Swagger 스펙 정의

* fix: Conflict 오류 수정

* [ISSUE - 53] 에러 메시지 한글화 및 Swagger 예시 보강 (#63)

* feat: swagger 메타 어노테이션 확장 및 에러/요청 바디 커스터마이저 개

* feat: swagger spec 도메인 분리(auth/user/expert/master/chat)

* refactor: 컨트롤러에 spec 적

* fix: CORS PATCH 추

* feat: 이력서 엔티티/DTO 정의

* feat: 이력서 조회/생성/수정 서비스 및 리포지토리 추가

* feat: 이력서 CRUD API 컨트롤러 추가

* feat: 이력서 API Swagger 스펙 정의

* fix: JWT 필터 ObjectMapper 타입 정합성 수정

* feat: 이력서 검증 실패 메시지 매핑 추가

* feat: 요청 검증 메시지 한글화

* feat: 에러 메시지 한글화 및 검증 매핑 보강

* feat: Swagger 예시 한글화 및 메타 어노테이션 인식 개선

* feat: 현직자 임베딩 요청 DTO 추가

* fix: Conflict 오류 해결

* feat: STOMP 연결에서 access_token 쿠키로 인증하도록 개선 (#65)

* [ISSUE - 18] 웹소켓 핸드세이크 쿠키 AT 에러 로그추가 (#66)

* feat: STOMP 연결에서 access_token 쿠키로 인증하도록 개선

* fix: BFF 쿠키에러 원인파악위한 로그추

* fix: conflict 해결

* [ISSUE - 18] 웹소켓 로그추가 및 인터셉터 엔드포인트 추가  (#67)

* feat: STOMP 연결에서 access_token 쿠키로 인증하도록 개선

* fix: BFF 쿠키에러 원인파악위한 로그추

* fix: conflict 해결

* feat: WebSocket 로그 추가 및 addInterceptors 엔드포인트 추가

* [ISSUE - #18] 채팅 실시간 publish 기능 추가 (#68)

* feat: STOMP 연결에서 access_token 쿠키로 인증하도록 개선

* fix: BFF 쿠키에러 원인파악위한 로그추

* fix: conflict 해결

* feat: WebSocket 로그 추가 및 addInterceptors 엔드포인트 추가

* feat: 실시간 publish 기능 추

* [ISSUE - #18] 채팅 publish 기능 service로 이관 (#69)

* feat: STOMP 연결에서 access_token 쿠키로 인증하도록 개선

* fix: BFF 쿠키에러 원인파악위한 로그추

* fix: conflict 해결

* feat: WebSocket 로그 추가 및 addInterceptors 엔드포인트 추가

* feat: 실시간 publish 기능 추

* feat: 채팅 메시지 저장 후 실시간 전송을 서비스에서 처리

* [ISSUE - # 62] SLI/SLO 기반 CD 검증 (#71)

* ci: SLI/SLO 기반 CD 검증

- 배포 전 검증 job 추가 (Error Budget 소진률 75% 이상 시 배포 중단)
- 배포 후 검증 step 추가 (배포 직후 서비스 품질 확인)
- CloudWatch 메트릭 조회 방식 개선
- Tier 1 API 6개에 대한 SLO 목표값 설정

* refactor: CI/CD 워크플로우 일관성 개선

- 브랜치 참조를 github.ref_name으로 통일
- environment 조건 단순화
- CD 워크플로우에 workflow_dispatch 입력 추가
- CI release job에서 CD 워크플로우 자동 트리거 추가

* fix: cd.yml YAML 문법 오류 수정

- 삼항 연산자(?)를 && || 패턴으로 변경하여 YAML 파서 오류 해결
- environment 조건문을 YAML 호환 형식으로 수정

* test: ci/BE-62/cd-SLI-SLO-test 브랜치 테스트 임시 추가

- CI 워크플로우에 테스트 브랜치 추가 (push, pull_request)
- CD 워크플로우에 테스트 브랜치 추가 (workflow_run, workflow_dispatch)
- integration, release job에서 테스트 브랜치 지원

* fix: Error Budget 소진률 계산 로직 수정

- 가용성 차이 기반으로 계산하도록 변경 (100% 초과 방지)
- 4xx 제외, 5xx만 서버 에러로 계산
- CloudWatch 메트릭 합산 계산 수정 (모든 데이터 포인트 포함)
- 가용성 계산 정밀도 향상 및 디버깅 로그 추가

* fix: Error Budget 소진률 계산 로직 수정

- burn_rate 변수 초기화 추가
- 소진률 최대값 100%로 제한
- error_budget 계산 정밀도 향상

* fix: SLO 목표값 조정 및 검증 로직 개선

* fix: CD SSM 배포 헬스체크 조건 및 로깅 보완

* fix: CD SSM 배포 스크립트에서 EC2 헬스체크 제거

* chore: ci/BE-62/cd-SLI-SLO-test 브랜치 적용 제거

* Update issue templates

* ci: 수동 롤백 workflow 추가 (#73)

* [ISSUE - #76] 내정보 수정 API 및 현직자 인증 상태 조회 API 추가 (#77)

* feat: 내 정보 수정 및 현직자 인증 상태 조회 추가 #105

* feat: 내 정보 수정 검증 예외 추(닉네임 중복/이미지 URL/빈 배열) #105

* feat: 알 수 없는 요청 필드 400 처리 #105

* feat: 작업(Task) 도메인 모델 추가 #74 (#75)

* [ISSUE - #64] 이력서 파싱 작업 API 추가 및 응답 매핑 (#78)

* feat: 작업(Task) 도메인 모델 추가 #74

* feat: 이력서 파싱 작업 API 추가 #64

* feat: 이력서 파싱 작업 API 문서화 #64

* feat: 이력서 파싱 전 저장을 위한 nullable 전환 #64

* feat: 이력서 파싱 관련 에러코드 추가 #64

* [ISSUE - #64] 운영 관리 엔드포인트/메트릭 설정 추가 및 INVALID 필드 400처리 (#79)

* feat: 작업(Task) 도메인 모델 추가 #74

* feat: 이력서 파싱 작업 API 추가 #64

* feat: 이력서 파싱 작업 API 문서화 #64

* feat: 이력서 파싱 전 저장을 위한 nullable 전환 #64

* feat: 이력서 파싱 관련 에러코드 추가 #64

* feat: 운영 관리 엔드포인트/메트릭 설정 추가 및 INVALID 필드 400처리

* feat: 내 정보 수정 시 직무/스킬 동기화 로직 개선 (#80)

* [ISSUE - #81] S3 Presigned URL 발급 기능 구현 (#82)

* feat: presigned url 요청 구조 개편 및 서버 경로 생성 로직 추가

* feat: presigned url 발급을 위한 s3 클라이언트 구성 추가

* feat: presigned url 발급 스웨거 스펙 추가

* feat: aws s3 sdk 의존성 추가

* [ISSUE - #85] dev 전용 API/정적 리소스 접근 차단 (#89)

* feat: dev 전용 API를 dev 프로파일로 제

* feat: 배포환경에서 /dev 정적 리소스 접근 차

* feat: dto 컬럼 추가 (#91)

* [ISSUE - #90] 채팅 메시지 client_message_id 지원 (#92)

* feat: dto 컬럼 추가

* feat: 채팅 메시지에 client_message_id 저장 및 응답 노출

* [ISSUE - #93] 채팅방 기반 이력서 presigned 다운로드 권한 검증 (#94)

* feat: 채팅방 기반 이력서 presigned 다운로드 권한 검증 추가

* feat: presigned 다운로드 GET/POST 분리 및 스웨거 명세 추가

* feat: presigned 발급용 storage 타입 구조 분리

* chore: gitignore 추가

* [ISSUE - #95] 이메일 인증 완료 시 현직자 전환 및 프로필 이미지 null 허용 (#96)

* feat: 이메일 인증 완료 시 EXPERT 전환 및 프로필 생성

* feat: 회원가입 프로필 이미지 null 허용

* feat: 이메일 인증 API 보안 스키마명 정합

* ci: SLI/SLO 로직 제거

- CD 워크플로우 내 SLI/SLO 검증하는 것은 부적절하다고 판단
- 모니터링 툴로 SLI/SLO 검증 전환

* feat: Swagger 경로 Basic 인증 활성 (#97)

* [ISSUE - #87] RateLimit 적용 및 WebSocket 전송 제한 추가 (#98)

* feat: 로컬 RateLimit 코어/정책 추가

* feat: 로컬 RateLimit 결과/로직 및 예외 타입 정비

* feat: HTTP 요청에 RateLimit 필터/인터셉터 적용

* feat: WebSocket 메시지 RateLimit 추가

* [ISSUE - #99] AT 만료시간 수정 및 이메일 도메인 수정 (#100)

* refactor: AT 만료시간 20초로 수정

* refactor: 이메일 도메인 수정

* fix: JAR 파일 업데이트 버그 수정

* ci: 헬스체크 시간 조정 (런타임 고려)

* fix: CD 중복 실행 버그 수정

* ci: main 브랜치에서만 배포 실행

* [ISSUE - #104] 이력서 파싱 요청 시 presigned URL 적용 (#105)

* release: v1.0.0 (#101)

* feat: 공통 응답 Response 구현

* feat: 전역 예외 처리 구

* feat: 기본 BaseEntity 구현

* chore: SwaggerConfig 추가

* feat: User 기본 구조 구현

* feat: 마스터 테이블 기본 구조 구현

* feat: User-마스터테이블 연관관계 테이블 구현

* feat: Oauth 회원가입/로그인 구현

* chore: yml, 의존성 수

* chore: yml, 의존성 수정

* chore: SecurityConfig, CorsConfig 초안 작성

* chore: Oauth관련 minor commit

* test: local Oauth 테스트 페이지

* feat: 회원 및 마스터 테이블 조회 기능 추가 (#12)

* feat: 회원 조회 관련 기능 추

* feat: 마스터 테이블 조회 기능 추가
- 직무, 경력은 테이블 전체 조회
- 기술은 파라미터에 따라 조건 검

* chore: cors, prod 설정

* feat: 의존성 추가 및 config (#14)

* feat: 회원 조회 관련 기능 추

* feat: 마스터 테이블 조회 기능 추가
- 직무, 경력은 테이블 전체 조회
- 기술은 파라미터에 따라 조건 검

* chore: cors, prod 설정

* chore: jwt 관련 의존성 및 yml 설정

* fix: EnableConfigurationProperties Config설정

* ci: CI/CD 워크플로우 파일 추가

* Update issue templates

* fix: Swagger, Security Conifg 수정 (#16)

* feat: 회원 조회 관련 기능 추

* feat: 마스터 테이블 조회 기능 추가
- 직무, 경력은 테이블 전체 조회
- 기술은 파라미터에 따라 조건 검

* chore: cors, prod 설정

* chore: jwt 관련 의존성 및 yml 설정

* fix: EnableConfigurationProperties Config설정

* fix: Swagger, Security Config 수정 #15

* fix: conflict fix

* fix: ddl-auto fix

* chore: application-secret.yml 파일 주입으로 변경

- 기존: application-oauth2.yml, application-prod.yml 파일 주입
- 변경: 모든 secret을 application-secret.yml로 관리하여 각 파일에 주입되도록 변경

* ci: CI/CD 워크플로우 개선

- 시크릿 파일을 application-secret.yml 하나로 통합
- 서버 경로를 SERVER_BASE_PATH로 통합 관리
- CI에서 빌드한 아티팩트를 반드시 사용하도록 변경
- workflow_dispatch와 workflow_run 분리 처리
- 아티팩트 다운로드 실패 시 명확한 에러 메시지 제공

* fix: CD 워크플로우 checkout token 에러 수정

- workflow_run과 workflow_dispatch에 따라 checkout 단계 분리
- workflow_run일 때만 PAT 토큰 사용

* fix: CD 배포 검증 개선 - 대기 시간 단축 및 디버깅 정보 추가

- 배포 검증 대기 시간 15초에서 10초로 단축
- HTTP Status Code 출력 추가
- 배포 실패 시 PM2 상태 및 로그 출력 추가

* refactor: Spring Boot 설정 파일 구조 개선 및 optional import 추가

- application.yml: spring.config.import로 application-secret.yml을 optional로 추가
- spring.profiles.include에서 secret 제거하여 중복 방지
- application-prod.yml에서 중복된 datasource 설정 제거
- application-secret.yml의 Spring Boot 설정 구조가 정상적으로 로드되도록 개선

* refactor: CI/CD 워크플로우 예외 처리 및 안정성 개선

CD 워크플로우:
- 헬스 체크 재시도 로직 추가 (최대 3회, 총 25초 대기)
- 파일 복사 및 디렉토리 생성 실패 시 에러 처리 추가
- PM2 시작 확인 로직 개선
- Caddy 리로드 실패 시 경고 메시지 출력
- PAT 제거하여 기본 GITHUB_TOKEN 사용

CI 워크플로우:
- 모든 Gradle 명령어 실패 시 명확한 에러 메시지 출력
- Dependency Vulnerability Check에 continue-on-error 추가
- JAR 검증 단계 예외 처리 개선
- Git tag 생성/푸시 실패 시 에러 처리 추가
- Secret 파일 주입 시 디렉토리 생성 및 쓰기 실패 처리

* ci: 단계별 로그 메시지 추가 및 불필요한 로직 제거

* fix: 아티팩트 업로드 경로 수정

- Archive JAR Artifact 단계의 경로를 절대 경로로 수정
- working-directory 설정이 uses 액션에 적용되지 않는 문제 해결

* fix: CI 아티팩트 전파 지연 대응

- workflow_run 트리거에서 아티팩트 조회 지연으로 download 실패하는 문제 방지
- 다운로드 전 아티팩트 존재 여부를 폴링 후 진행

* fix: 아티팩트 다운로드 전파 지연 대응 (로직 변경)

- workflow_run 트리거에서 간헐적으로 Artifact not found 발생하는 문제 대응
- actions/download-artifact 대신 gh run download + 재시도 로직 적용

* docs: PR 템플릿 추가

* feat: JWT 인증/인가 및 내정보 조회 API 추가 (#17)

* feat: 회원 조회 관련 기능 추

* feat: 마스터 테이블 조회 기능 추가
- 직무, 경력은 테이블 전체 조회
- 기술은 파라미터에 따라 조건 검

* chore: cors, prod 설정

* chore: jwt 관련 의존성 및 yml 설정

* fix: EnableConfigurationProperties Config설정

* feat: refreshtoken 도메인 추가

* feat: Auth Dto 추가

* feat: feat: JWT 인증 필터 및 보안 설정 #13

* feat: RTR 기반 토큰 재발급 및 로그인 응답 토큰 포

* feat: 개발 토큰 발급 API 추가

* feat: 내 정보 조회 API 및 응답 DTO 추가

* feat: Swagger 보안 스키마 및 sprigdoc 설정 추가

* chore: cors 도메인 정리

* fix: conflict fix

* fix: CI job별 브랜치 checkout 설정 수정

* fix: SecurityConfig, prod-swagger설정 수정 (#19)

* fix: CD 헬스체크 URL을 실제 서비스 도메인으로 변경

* fix: prod-Swagger config 수정 (#20)

* fix: SecurityConfig, prod-swagger설정 수정

* fix: prod-swagger설정 수정

* chore: CD 헬스체크 재시도 횟수 조정

- 총 대기 시간: 15초 초기 대기 + 5회 × 5초 = 40초

* Update issue templates

* remove: Pull Request 템플릿 삭제

- 레포지토리 Settings에서 설정하여 템플릿 재생성

* fix: Security 수정 (#21)

* fix: SecurityConfig, prod-swagger설정 수정

* fix: prod-swagger설정 수정

* fix: SecurityConfig 수정

* fix: Security Config 수정 2 (#22)

* fix: SecurityConfig, prod-swagger설정 수정

* fix: prod-swagger설정 수정

* fix: SecurityConfig 수정

* fix: SecurityConfig 수정 - 2

* fix: api controller url (#23)

* fix: SecurityConfig, prod-swagger설정 수정

* fix: prod-swagger설정 수정

* fix: SecurityConfig 수정

* fix: SecurityConfig 수정 - 2

* fix: api 경로 제거

* fix: api 경로 원복 및 yml 수정 (#24)

* fix: SecurityConfig, prod-swagger설정 수정

* fix: prod-swagger설정 수정

* fix: SecurityConfig 수정

* fix: SecurityConfig 수정 - 2

* fix: api 경로 제거

* fix: api 경로 원복, yml 수

* fix: yml 원복 (#25)

* fix: SecurityConfig, prod-swagger설정 수정

* fix: prod-swagger설정 수정

* fix: SecurityConfig 수정

* fix: SecurityConfig 수정 - 2

* fix: api 경로 제거

* fix: api 경로 원복, yml 수

* fix: yml 원복

* fix: context-path 설정 (#26)

* fix: SecurityConfig, prod-swagger설정 수정

* fix: prod-swagger설정 수정

* fix: SecurityConfig 수정

* fix: SecurityConfig 수정 - 2

* fix: api 경로 제거

* fix: api 경로 원복, yml 수

* fix: yml 원복

* fix: context-path 설정

* fix: conflict fix - 1

* fix: conflict fix - 2

* fix: conflict fix - 3

* fix: Security 전역 설정 및 prod-yml 원복 (#27)

* fix: SecurityConfig, prod-swagger설정 수정

* fix: prod-swagger설정 수정

* fix: SecurityConfig 수정

* fix: SecurityConfig 수정 - 2

* fix: api 경로 제거

* fix: api 경로 원복, yml 수

* fix: yml 원복

* fix: context-path 설정

* fix: Security 전역설정 및 prod 롤백

* fix: api 경로 원

* Feature/be 18/chat domain feature 2 (#28)

* fix: SecurityConfig, prod-swagger설정 수정

* fix: prod-swagger설정 수정

* fix: SecurityConfig 수정

* fix: SecurityConfig …

---
name: Pull-Request-Template
about: Pull Request 템플릿
title: "[이슈유형] {이슈 내용}"
labels: ''
assignees: Eeeegarden

---

## 변경 사항
- 주요 기능/버그 수정 요약

## 상세 내용
- 핵심 로직 설명 및 리뷰 시 참고 사항

## 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.

## 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.
  
## 연관된 이슈

> ex) #이슈번호, #이슈번호

## 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.
