### PR TITLE
[ISSUE - #145] 회원탈퇴 후 재가입 중복 매핑 오류 수정

### DIFF
--- a/refit-backend/src/main/java/org/refit/refitbackend/domain/user/repository/UserJobRepository.java
+++ b/refit-backend/src/main/java/org/refit/refitbackend/domain/user/repository/UserJobRepository.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface UserJobRepository extends JpaRepository<UserJob, Integer> {
+ public interface UserJobRepository extends JpaRepository<UserJob, Long> {
     void deleteByUser_Id(Long userId);
 
     @Query("""

--- a/refit-backend/src/main/java/org/refit/refitbackend/domain/user/repository/UserSkillRepository.java
+++ b/refit-backend/src/main/java/org/refit/refitbackend/domain/user/repository/UserSkillRepository.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface UserSkillRepository extends JpaRepository<UserSkill, Integer> {
+public interface UserSkillRepository extends JpaRepository<UserSkill, Long> {
     void deleteByUser_Id(Long userId);
 
     @Query("""

--- a/refit-backend/src/main/java/org/refit/refitbackend/domain/user/service/UserService.java
+++ b/refit-backend/src/main/java/org/refit/refitbackend/domain/user/service/UserService.java
@@ -144,7 +144,7 @@ public class UserService {
         }
 
         String anonymizedEmail = "deleted_" + userId + "@anonymized.local";
-        String anonymizedNickname = "탈퇴회원" + userId;
+        String anonymizedNickname = buildAnonymizedNickname(userId);
         user.markDeleted(anonymizedEmail, anonymizedNickname);
 
         refreshTokenRepository.updateStatusByUserAndStatus(
@@ -193,6 +193,20 @@ public class UserService {
         String nextCursor = users.isEmpty() ? null : String.valueOf(users.get(users.size() - 1).getId());
 
         return new CursorPage<>(items, nextCursor, hasMore);
+    }
+
+    private String buildAnonymizedNickname(Long userId) {
+        String base = "탈퇴회원";
+        String suffix = String.valueOf(userId);
+        int maxLen = 10;
+        if (base.length() >= maxLen) {
+            return base.substring(0, maxLen);
+        }
+        int remaining = maxLen - base.length();
+        if (suffix.length() > remaining) {
+            suffix = suffix.substring(0, remaining);
+        }
+        return base + suffix;
     }
 
     private void validateNickname(String nickname) {


### PR DESCRIPTION
## 변경 사항

  - 탈퇴 후 재가입 시 user_jobs/user_skills 중복 제약 위반 해결
  - 매핑 동기화 로직을 diff 기반으로 전환

  ## 상세 내용

  - 기존 매핑 조회 후 삭제/추가/수정만 수행하도록 변경
  - 중복 요청값은 정규화하여 삽입 충돌 방지
  - display_order 변경은 업데이트 처리

  ## 체크리스트

  - [X] 기능이 정상적으로 동작하는지 확인했습니다.
  - [x] 기존 기능에 영향을 주지 않는지 확인했습니다.

  ## 리뷰 요청 사항

  - 

  ## 연관된 이슈

  - #145 

  ## 참고 자료 (선택)

  - 없음