### PR TITLE
[ISSUE - #152] 채팅 마지막 메시지 DTO에 room_sequence 필드 추가

### DIFF
--- a/refit-backend/src/main/java/org/refit/refitbackend/domain/chat/dto/ChatRes.java
+++ b/refit-backend/src/main/java/org/refit/refitbackend/domain/chat/dto/ChatRes.java
@@ -212,6 +212,9 @@ public class ChatRes {
             @Schema(description = "메시지 ID", example = "1")
             Long messageId,
 
+            @Schema(description = "채팅방 내 메시지 시퀀스(읽음 처리 기준)", example = "100")
+            Long roomSequence,
+
             @Schema(description = "메시지 내용", example = "안녕하세요!")
             String content,
 
@@ -222,6 +225,7 @@ public class ChatRes {
         public static LastMessageInfo from(ChatMessage message) {
             return new LastMessageInfo(
                     message.getId(),
+                    message.getRoomSequence(),
                     message.getContent(),
                     message.getCreatedAt()
             );

--- a/refit-backend/src/main/java/org/refit/refitbackend/domain/chat/service/ChatRoomService.java
+++ b/refit-backend/src/main/java/org/refit/refitbackend/domain/chat/service/ChatRoomService.java
@@ -208,6 +208,7 @@ public class ChatRoomService {
     /**
      * 채팅방 메시지 목록 조회 (커서)
      */
+    @Transactional
     public CursorPage<ChatRes.MessageInfo> getMessages(
             Long userId,
             Long roomId,
@@ -224,9 +225,9 @@ public class ChatRoomService {
                 PageRequest.of(0, size + 1)
         );
 
-        if (!messages.isEmpty()) {
-            ChatMessage latest = messages.get(0); // id DESC 기준
-            room.updateLastReadMessage(userId, latest);
+        if (room.getLastMessageSeq() != null) {
+            // 메시지 페이지 커서와 무관하게, 방에 존재하는 최신 메시지까지 읽음 처리
+            room.updateLastReadSeq(userId, room.getLastMessageSeq());
         }
 
         boolean hasMore = messages.size() > size;


### PR DESCRIPTION
## 변경 사항
  - 채팅방 목록 응답의 `last_message` DTO에 `room_sequence` 필드를 추가했습니다.
  - 읽음 처리 시 `message_id`가 아닌 `room_sequence` 기준으로 값을 전달할 수 있도록 응답 스펙을 보완했습니다.

  ## 상세 내용
  - 수정 파일: `src/main/java/org/refit/refitbackend/domain/chat/dto/ChatRes.java`
  - 변경 내용:
    - `LastMessageInfo`에 `roomSequence` 필드 추가
    - `LastMessageInfo.from(ChatMessage)`에서 `message.getRoomSequence()` 매핑 추가
  - 목적:
    - 프론트에서 `last_read_seq` 생성 시 기준값 혼동(`message_id` vs `room_sequence`) 방지
    - 읽음 처리 API(`PATCH /.../last-read-message`)와 데이터 계약 정합성 강화

  ## 체크리스트
  - [x] 기능이 정상적으로 동작하는지 확인했습니다.
  - [x] 기존 기능에 영향을 주지 않는지 확인했습니다.

  ## 리뷰 요청 사항
  - 

  ## 연관된 이슈

  > #152 


  ## 참고 자료 (선택)
