### PR TITLE
[ISSUE - #154] 멘토 임베딩 갱신 API 추가 및 회원가입/프로필 변경 자동 연동

### DIFF
--- a/refit-backend/src/main/java/org/refit/refitbackend/domain/expert/controller/ExpertController.java
+++ b/refit-backend/src/main/java/org/refit/refitbackend/domain/expert/controller/ExpertController.java
@@ -19,6 +19,7 @@ import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -95,6 +96,14 @@ public class ExpertController {
     ) {
         expertService.updateEmbedding(request);
         return ResponseUtil.ok("success");
+    }
+
+    @ExpertSwaggerSpec.RefreshMentorEmbedding
+    @PutMapping("/embeddings/{user_id}")
+    public ResponseEntity<ApiResponse<ExpertRes.MentorEmbeddingUpdateResponse>> refreshMentorEmbedding(
+            @PathVariable("user_id") @Positive(message = "expert_user_id_invalid") Long userId
+    ) {
+        return ResponseUtil.ok("success", expertService.refreshMentorEmbedding(userId));
     }
 
     private Long resolveUserId(Long userIdQueryParam, String authorization) {

--- a/refit-backend/src/main/java/org/refit/refitbackend/domain/expert/dto/ExpertRes.java
+++ b/refit-backend/src/main/java/org/refit/refitbackend/domain/expert/dto/ExpertRes.java
@@ -154,4 +154,11 @@ public class ExpertRes {
             Integer totalCount,
             Object evaluation
     ) {}
+
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public record MentorEmbeddingUpdateResponse(
+            boolean success,
+            Long userId,
+            String message
+    ) {}
 }

--- a/refit-backend/src/main/java/org/refit/refitbackend/global/swagger/spec/expert/ExpertSwaggerSpec.java
+++ b/refit-backend/src/main/java/org/refit/refitbackend/global/swagger/spec/expert/ExpertSwaggerSpec.java
@@ -4,6 +4,7 @@ import org.refit.refitbackend.domain.expert.dto.ExpertRes;
 import org.refit.refitbackend.domain.expert.dto.ExpertReq;
 import org.refit.refitbackend.global.error.ExceptionType;
 import org.refit.refitbackend.global.swagger.annotation.SwaggerApiBadRequestError;
+import org.refit.refitbackend.global.swagger.annotation.SwaggerApiError;
 import org.refit.refitbackend.global.swagger.annotation.SwaggerApiNotFoundError;
 import org.refit.refitbackend.global.swagger.annotation.SwaggerApiRequestBody;
 import org.refit.refitbackend.global.swagger.annotation.SwaggerApiSuccess;
@@ -62,6 +63,24 @@ public final class ExpertSwaggerSpec {
             exampleNames = { "update_embedding" }
     )
     public @interface UpdateEmbedding {}
+
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @SwaggerApiSuccess(
+            summary = "멘토 임베딩 갱신 요청",
+            operationDescription = "AI 서버에 특정 멘토 임베딩 계산/전송을 요청합니다.",
+            implementation = ExpertRes.MentorEmbeddingUpdateResponse.class
+    )
+    @SwaggerApiBadRequestError(types = {
+            ExceptionType.EXPERT_USER_ID_INVALID
+    })
+    @SwaggerApiNotFoundError(description = "expert_not_found", types = {
+            ExceptionType.EXPERT_NOT_FOUND
+    })
+    @SwaggerApiError(responseCode = "500", description = "ai_server_error", types = {
+            ExceptionType.AI_SERVER_ERROR
+    })
+    public @interface RefreshMentorEmbedding {}
 
     @Target(ElementType.METHOD)
     @Retention(RetentionPolicy.RUNTIME)


### PR DESCRIPTION
## 변경 사항

  - 백엔드에 멘토 임베딩 개별 갱신 API를 추가했습니다.
  - 회원가입(EXPERT) 및 프로필(직무/스킬) 변경 시 AI 임베딩 갱신 호출을 자동 연동했습니다.
  - 관련 응답 DTO 및 Swagger 문서를 함께 반영했습니다.

  ## 상세 내용

  - PUT /api/v1/experts/embeddings/{user_id} 엔드포인트를 추가해 AI 서버 PUT /api/ai/mentors/embeddings/{user_id}를 호출하도록 구현했습니다.
  - AI 응답(success, user_id, message)을 백엔드 응답 DTO로 매핑했습니다.
  - AI 호출 실패 시:
      - 수동 임베딩 갱신 API에서는 예외를 반환하도록 처리했습니다.
      - 회원가입/프로필 변경 자동 호출에서는 비즈니스 플로우를 막지 않도록 best-effort(로그 기록 후 진행)로 처리했습니다.
  - 회원가입 로직(AuthService)에서 EXPERT 사용자 생성/복구 시 임베딩 갱신 호출을 추가했습니다.
  - 프로필 수정 로직(UserService)에서 job_ids 또는 skills 변경 시 임베딩 갱신 호출을 추가했습니다.
  - Swagger 스펙에 신규 API 문서 및 에러 케이스를 추가했습니다.

  ## 체크리스트

  - [x] 기능이 정상적으로 동작하는지 확인했습니다.
  - [x] 기존 기능에 영향을 주지 않는지 확인했습니다.

  ## 리뷰 요청 사항

  ## 연관된 이슈

  > #154                                                                                                                                                                           

  ## 참고 자료 (선택)
