### PR TITLE
[ISSUE - #171] FCM 설정 순환 참조 제거 및 WebSocket 인증 로그 노이즈 개선

### DIFF
--- a/refit-backend/src/main/java/org/refit/refitbackend/global/websocket/JwtChannelInterceptor.java
+++ b/refit-backend/src/main/java/org/refit/refitbackend/global/websocket/JwtChannelInterceptor.java
@@ -30,8 +30,8 @@ public class JwtChannelInterceptor implements ChannelInterceptor {
         StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
 
         if (accessor != null && StompCommand.CONNECT.equals(accessor.getCommand())) {
-            log.info("[WS] CONNECT headers: {}", accessor.toNativeHeaderMap());
-            log.info("[WS] session attributes: {}", accessor.getSessionAttributes());
+            log.debug("[WS] CONNECT headers: {}", accessor.toNativeHeaderMap());
+            log.debug("[WS] session attributes: {}", accessor.getSessionAttributes());
             String token = extractToken(accessor);
             if (token != null && !token.isBlank()) {
                 authenticateUser(accessor, token);
@@ -85,7 +85,7 @@ public class JwtChannelInterceptor implements ChannelInterceptor {
             log.info("WebSocket 인증 성공 - userId: {}", userId);
 
         } catch (Exception e) {
-            log.error("WebSocket 인증 실패", e);
+            log.warn("WebSocket 인증 실패: {}", e.getMessage());
         }
     }
 

--- a/refit-backend/src/main/resources/application-dev.yml
+++ b/refit-backend/src/main/resources/application-dev.yml
@@ -57,10 +57,6 @@ springdoc:
 fcm:
   enabled: true
   credentials-path: ${FCM_CREDENTIALS_PATH:./src/main/resources/firebase/refit-fcm.json}
-  file_path: ${FCM_CREDENTIALS_PATH:./src/main/resources/firebase/refit-fcm.json}
-  project_id: ${FCM_PROJECT_ID:${fcm.project-id:}}
-  url: https://fcm.googleapis.com/v1/projects/${FCM_PROJECT_ID:${fcm.project-id:}}/messages:send
-  google_api: https://www.googleapis.com/auth/cloud-platform
 
 # ============================================
 # Actuator & Prometheus (개발 환경)

--- a/refit-backend/src/main/resources/application-prod.yml
+++ b/refit-backend/src/main/resources/application-prod.yml
@@ -94,8 +94,3 @@ server:
 fcm:
   enabled: ${FCM_ENABLED:true}
   credentials-path: ${FCM_CREDENTIALS_PATH:./src/main/resources/firebase/refit-fcm.json}
-  project-id: ${FCM_PROJECT_ID:${fcm.project-id:}}
-  file_path: ${FCM_CREDENTIALS_PATH:./src/main/resources/firebase/refit-fcm.json}
-  project_id: ${FCM_PROJECT_ID:${fcm.project-id:}}
-  url: https://fcm.googleapis.com/v1/projects/${FCM_PROJECT_ID:${fcm.project-id:}}/messages:send
-  google_api: https://www.googleapis.com/auth/cloud-platform


### PR DESCRIPTION
## 변경 사항

  - FCM 설정 순환 참조로 인한 애플리케이션 기동 실패 수정
  - WebSocket CONNECT 인증 실패 로그 노이즈 완화

  ## 상세 내용

  - application-dev.yml, application-prod.yml의 FCM 레거시 키(project_id, file_path, url, google_api) 정리
  - fcm.project-id는 application-secret.yml의 값만 사용하도록 정리
  - JwtChannelInterceptor 로그 레벨 조정
      - CONNECT 헤더/세션 로그: info → debug
      - 인증 실패 로그: error(stacktrace) → warn(메시지 1줄)

  ## 체크리스트

  - [x] 기능이 정상적으로 동작하는지 확인했습니다.
  - [x] 기존 기능에 영향을 주지 않는지 확인했습니다.

  ## 리뷰 요청 사항

  - 

  ## 연관된 이슈

  > #171

  ## 참고 자료 (선택)

  -