### PR TITLE
[ISSUE - #182] 채팅방 상세 조회 응답에 요청 타입(requestType) 추가

### DIFF
--- a/refit-backend/src/main/java/org/refit/refitbackend/domain/chat/dto/ChatRes.java
+++ b/refit-backend/src/main/java/org/refit/refitbackend/domain/chat/dto/ChatRes.java
@@ -93,6 +93,9 @@ public class ChatRes {
             @Schema(description = "공고 URL", example = "https://example.com/job/123")
             String jobPostUrl,
 
+            @Schema(description = "채팅 요청 타입 (요청 기반 채팅인 경우)", example = "FEEDBACK", nullable = true)
+            String requestType,
+
             @Schema(description = "채팅방 상태", example = "ACTIVE")
             String status,
 
@@ -104,7 +107,7 @@ public class ChatRes {
             @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
             LocalDateTime closedAt
     ) {
-        public static RoomDetail from(ChatRoom room, ResumeInfo resume) {
+        public static RoomDetail from(ChatRoom room, ResumeInfo resume, String requestType) {
             return new RoomDetail(
                     room.getId(),
                     UserInfo.from(room.getRequester()),
@@ -112,6 +115,7 @@ public class ChatRes {
                     room.getResumeId(),
                     resume,
                     room.getJobPostUrl(),
+                    requestType,
                     room.getStatus().name(),
                     room.getCreatedAt(),
                     room.getClosedAt()

--- a/refit-backend/src/main/java/org/refit/refitbackend/domain/chat/service/ChatRoomService.java
+++ b/refit-backend/src/main/java/org/refit/refitbackend/domain/chat/service/ChatRoomService.java
@@ -185,7 +185,14 @@ public class ChatRoomService {
             }
         }
 
-        return ChatRes.RoomDetail.from(room, resumeInfo);
+        String requestType = null;
+        if (room.getChatRequestId() != null) {
+            requestType = chatRequestRepository.findById(room.getChatRequestId())
+                    .map(request -> request.getRequestType().name())
+                    .orElse(null);
+        }
+
+        return ChatRes.RoomDetail.from(room, resumeInfo, requestType);
     }
 
     /**


### PR DESCRIPTION
  ## 변경 사항
  - 채팅방 상세 조회 응답에 `requestType` 필드 추가

  ## 상세 내용
  - `ChatRes.RoomDetail`에 `requestType` 필드를 추가했습니다.
  - `ChatRoomService.getRoomDetail()`에서 `chatRequestId` 기준으로 요청 타입(`FEEDBACK`/`COFFEE_CHAT`)을 조회해 응답에 포함하도록 수정했습니다.
  - 요청 기반 채팅이 아닌 경우 `requestType`은 `null`로 내려갑니다.

  ## 체크리스트
  - [x] 기능이 정상적으로 동작하는지 확인했습니다.
  - [x] 기존 기능에 영향을 주지 않는지 확인했습니다.

  ## 리뷰 요청 사항


  ## 연관된 이슈

  > #182 