### PR TITLE
[ISSUE - #193] 채팅 요청 응답 알림 추가 및 PENDING 중복 요청 제한

### DIFF
--- a/refit-backend/src/main/java/org/refit/refitbackend/domain/chat/service/ChatRequestService.java
+++ b/refit-backend/src/main/java/org/refit/refitbackend/domain/chat/service/ChatRequestService.java
@@ -43,13 +43,14 @@ public class ChatRequestService {
         if (requesterId.equals(request.receiverId())) {
             throw new CustomException(ExceptionType.INVALID_REQUEST);
         }
+        ChatRequestType requestType = parseRequestType(request.requestType());
+
         if (chatRequestRepository.existsByRequesterIdAndReceiverIdAndStatus(
                 requesterId, request.receiverId(), ChatRequestStatus.PENDING
         )) {
             throw new CustomException(ExceptionType.CHAT_REQUEST_ALREADY_EXISTS);
         }
 
-        ChatRequestType requestType = parseRequestType(request.requestType());
         validateRequestPayload(requestType, request.resumeId(), request.jobPostUrl());
         validateResumeOwnership(requesterId, request.resumeId());
 
@@ -124,8 +125,19 @@ public class ChatRequestService {
                     .build());
             chatRequest.accept();
             chatId = room.getId();
+            notificationService.notifyChatRequestAccepted(
+                    chatRequest.getRequester(),
+                    chatRequest.getReceiver(),
+                    chatRequest.getId(),
+                    chatId
+            );
         } else {
             chatRequest.reject();
+            notificationService.notifyChatRequestRejected(
+                    chatRequest.getRequester(),
+                    chatRequest.getReceiver(),
+                    chatRequest.getId()
+            );
         }
 
         return new ChatRes.RespondRequestResult(chatRequest.getId(), chatRequest.getStatus().name(), chatId);

--- a/refit-backend/src/main/java/org/refit/refitbackend/domain/notification/service/NotificationService.java
+++ b/refit-backend/src/main/java/org/refit/refitbackend/domain/notification/service/NotificationService.java
@@ -156,6 +156,22 @@ public class NotificationService {
     }
 
     @Transactional
+    public void notifyChatRequestAccepted(User requester, User receiver, Long chatRequestId, Long chatId) {
+        String title = "채팅 요청이 수락되었어요";
+        String content = receiver.getNickname() + "님이 채팅 요청을 수락했습니다.";
+        String type = "CHAT_REQUEST_ACCEPTED";
+        sendNotification(requester, type, title, content);
+    }
+
+    @Transactional
+    public void notifyChatRequestRejected(User requester, User receiver, Long chatRequestId) {
+        String title = "채팅 요청이 거절되었어요";
+        String content = receiver.getNickname() + "님이 채팅 요청을 거절했습니다.";
+        String type = "CHAT_REQUEST_REJECTED";
+        sendNotification(requester, type, title, content);
+    }
+
+    @Transactional
     public void notifyResumeParseCompleted(Long userId, String taskId) {
         userRepository.findById(userId).ifPresent(user -> {
             String title = "이력서 분석이 완료됐어요";


### PR DESCRIPTION
  ## 변경 사항

  - 채팅 요청 수락/거절 시 요청자에게도 알림이 가도록 추가
  - 동일 요청자-수신자 조합에서 PENDING 요청 1건만 허용하도록 제한

  ## 상세 내용

  - ChatRequestService.respond에서 ACCEPTED/REJECTED 분기별 알림 발송 로직 추가
  - 요청 생성 시 중복 체크를 requesterId + receiverId + PENDING 기준으로 적용
  - 타입(FEEDBACK/COFFEE_CHAT)과 무관하게 대기 요청 중복 생성 차단

  ## 체크리스트

  - [x] 기능이 정상적으로 동작하는지 확인했습니다.
  - [x] 기존 기능에 영향을 주지 않는지 확인했습니다.

  ## 리뷰 요청 사항

  - 요청 상태 변경 알림 타입(CHAT_REQUEST_ACCEPTED, CHAT_REQUEST_REJECTED) 프론트 처리 매핑 확인 부탁드립니다.

  ## 연관된 이슈

  - #193 

  ## 참고 자료 (선택)

  - 없음
