### PR TITLE
[ISSUE - #200] 현직자 추천 API null 필드 매핑 오류 수정

### DIFF
--- a/refit-backend/src/main/java/org/refit/refitbackend/domain/auth/config/RestTemplateConfig.java
+++ b/refit-backend/src/main/java/org/refit/refitbackend/domain/auth/config/RestTemplateConfig.java
@@ -1,13 +1,15 @@
 package org.refit.refitbackend.domain.auth.config;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 @Configuration
 public class RestTemplateConfig {
@@ -15,10 +17,19 @@ public class RestTemplateConfig {
     @Bean
     public RestTemplate restTemplate() {
         RestTemplate restTemplate = new RestTemplate();
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
+
         // RestTemplate 이용 중 클라이언트의 한글 깨짐 증상에 대한 수정
         restTemplate.getMessageConverters().add(0, new StringHttpMessageConverter(StandardCharsets.UTF_8));
+
+        // AI 응답(user_id 등 snake_case)을 DTO(userId)로 역직렬화하기 위한 설정
+        List<HttpMessageConverter<?>> converters = restTemplate.getMessageConverters();
+        for (HttpMessageConverter<?> converter : converters) {
+            if (converter instanceof MappingJackson2HttpMessageConverter jacksonConverter) {
+                jacksonConverter.getObjectMapper()
+                        .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+            }
+        }
+
         return restTemplate;
     }
 }

--- a/refit-backend/src/main/java/org/refit/refitbackend/domain/expert/dto/ExpertRes.java
+++ b/refit-backend/src/main/java/org/refit/refitbackend/domain/expert/dto/ExpertRes.java
@@ -1,6 +1,7 @@
 package org.refit.refitbackend.domain.expert.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -130,27 +131,38 @@ public class ExpertRes {
 
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     public record RecommendationItem(
+            @JsonProperty("user_id")
             Long userId,
             String nickname,
+            @JsonProperty("company_name")
             String companyName,
             boolean verified,
+            @JsonProperty("rating_avg")
             Double ratingAvg,
+            @JsonProperty("rating_count")
             Integer ratingCount,
+            @JsonProperty("response_rate")
             Double responseRate,
             List<String> skills,
             List<String> jobs,
             String introduction,
+            @JsonProperty("similarity_score")
             Double similarityScore,
+            @JsonProperty("filter_type")
             String filterType,
+            @JsonProperty("ground_truth")
             String groundTruth,
+            @JsonProperty("last_active_at")
             @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
             LocalDateTime lastActiveAt
     ) {}
 
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     public record RecommendationResponse(
+            @JsonProperty("user_id")
             Long userId,
             List<RecommendationItem> recommendations,
+            @JsonProperty("total_count")
             Integer totalCount,
             Object evaluation
     ) {}
@@ -158,6 +170,7 @@ public class ExpertRes {
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     public record MentorEmbeddingUpdateResponse(
             boolean success,
+            @JsonProperty("user_id")
             Long userId,
             String message
     ) {}


### PR DESCRIPTION
  ## 변경 사항

  - 현직자 추천 응답에서 user_id 등 주요 필드가 null로 내려오던 문제 수정

  ## 상세 내용

  - ExpertRes DTO에 snake_case 필드 매핑(@JsonProperty)을 명시적으로 추가
  - 환경별 ObjectMapper 설정 차이가 있어도 응답 역직렬화가 안정적으로 동작하도록 보강

  ## 체크리스트

  - [x] 기능이 정상적으로 동작하는지 확인했습니다.
  - [x] 기존 기능에 영향을 주지 않는지 확인했습니다.

  ## 리뷰 요청 사항

  - 

  ## 연관된 이슈

  > #200                                                                                                                                                                   

  ## 참고 자료 (선택)

  - 