### PR TITLE
[ISSUE - #246] SSE 알림 다중 인스턴스 대응

### DIFF
--- a/refit-backend/src/main/java/org/refit/refitbackend/domain/notification/realtime/RedisNotificationRealtimeEvent.java
+++ b/refit-backend/src/main/java/org/refit/refitbackend/domain/notification/realtime/RedisNotificationRealtimeEvent.java
@@ -1,0 +1,9 @@
+package org.refit.refitbackend.domain.notification.realtime;
+
+public record RedisNotificationRealtimeEvent(
+        Long userId,
+        String notificationType,
+        Long notificationId,
+        long unreadCount
+) {
+}

--- a/refit-backend/src/main/java/org/refit/refitbackend/domain/notification/realtime/RedisNotificationRealtimePublisher.java
+++ b/refit-backend/src/main/java/org/refit/refitbackend/domain/notification/realtime/RedisNotificationRealtimePublisher.java
@@ -1,0 +1,33 @@
+package org.refit.refitbackend.domain.notification.realtime;
+
+import tools.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "app.notification.realtime.redis.enabled", havingValue = "true")
+public class RedisNotificationRealtimePublisher {
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Value("${app.notification.realtime.redis.channel:notification.event.broadcast}")
+    private String channel;
+
+    public void publish(Long userId, String notificationType, Long notificationId, long unreadCount) {
+        try {
+            String body = objectMapper.writeValueAsString(
+                    new RedisNotificationRealtimeEvent(userId, notificationType, notificationId, unreadCount)
+            );
+            stringRedisTemplate.convertAndSend(channel, body);
+        } catch (Exception e) {
+            log.error("Redis notification publish failed. userId={}, notificationId={}", userId, notificationId, e);
+        }
+    }
+}

--- a/refit-backend/src/main/java/org/refit/refitbackend/domain/notification/realtime/RedisNotificationRealtimeSubscriber.java
+++ b/refit-backend/src/main/java/org/refit/refitbackend/domain/notification/realtime/RedisNotificationRealtimeSubscriber.java
@@ -1,0 +1,62 @@
+package org.refit.refitbackend.domain.notification.realtime;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.refit.refitbackend.global.sse.SseService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "app.notification.realtime.redis.enabled", havingValue = "true")
+public class RedisNotificationRealtimeSubscriber implements MessageListener {
+
+    private final ObjectMapper objectMapper;
+    private final SseService sseService;
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        try {
+            String body = new String(message.getBody(), StandardCharsets.UTF_8);
+            JsonNode root = objectMapper.readTree(body);
+
+            JsonNode userIdNode = root.get("userId");
+            if (userIdNode == null || userIdNode.isNull()) {
+                userIdNode = root.get("user_id");
+            }
+            if (userIdNode == null || !userIdNode.canConvertToLong()) {
+                throw new IllegalArgumentException("userId missing in redis notification payload");
+            }
+
+            JsonNode notificationTypeNode = root.get("notificationType");
+            if (notificationTypeNode == null || notificationTypeNode.isNull()) {
+                notificationTypeNode = root.get("notification_type");
+            }
+            JsonNode notificationIdNode = root.get("notificationId");
+            if (notificationIdNode == null || notificationIdNode.isNull()) {
+                notificationIdNode = root.get("notification_id");
+            }
+            JsonNode unreadCountNode = root.get("unreadCount");
+            if (unreadCountNode == null || unreadCountNode.isNull()) {
+                unreadCountNode = root.get("unread_count");
+            }
+
+            sseService.sendNotificationEventLocal(
+                    userIdNode.longValue(),
+                    notificationTypeNode != null && !notificationTypeNode.isNull() ? notificationTypeNode.asText() : null,
+                    notificationIdNode != null && notificationIdNode.canConvertToLong() ? notificationIdNode.longValue() : null,
+                    unreadCountNode != null && unreadCountNode.canConvertToLong() ? unreadCountNode.longValue() : 0L
+            );
+        } catch (Exception e) {
+            log.error("Redis notification subscribe handling failed. body={}",
+                    new String(message.getBody(), StandardCharsets.UTF_8), e);
+        }
+    }
+}

--- a/refit-backend/src/main/java/org/refit/refitbackend/global/config/RedisNotificationPubSubConfig.java
+++ b/refit-backend/src/main/java/org/refit/refitbackend/global/config/RedisNotificationPubSubConfig.java
@@ -1,0 +1,37 @@
+package org.refit.refitbackend.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.refit.refitbackend.domain.notification.realtime.RedisNotificationRealtimeSubscriber;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+
+@Configuration
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "app.notification.realtime.redis.enabled", havingValue = "true")
+public class RedisNotificationPubSubConfig {
+
+    @Bean
+    public ChannelTopic notificationRealtimeTopic(
+            @Value("${app.notification.realtime.redis.channel:notification.event.broadcast}")
+            String channel
+    ) {
+        return new ChannelTopic(channel);
+    }
+
+    @Bean
+    public RedisMessageListenerContainer notificationRedisMessageListenerContainer(
+            RedisConnectionFactory connectionFactory,
+            RedisNotificationRealtimeSubscriber subscriber,
+            ChannelTopic notificationRealtimeTopic
+    ) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        container.addMessageListener(subscriber, notificationRealtimeTopic);
+        return container;
+    }
+}

--- a/refit-backend/src/main/java/org/refit/refitbackend/global/sse/SseService.java
+++ b/refit-backend/src/main/java/org/refit/refitbackend/global/sse/SseService.java
@@ -2,6 +2,7 @@ package org.refit.refitbackend.global.sse;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.refit.refitbackend.domain.notification.realtime.RedisNotificationRealtimePublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -9,6 +10,7 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -19,6 +21,7 @@ public class SseService {
     private static final long DEFAULT_TIMEOUT_MS = 30L * 60L * 1000L; // 30m
 
     private final SseEmitterRepository emitterRepository;
+    private final Optional<RedisNotificationRealtimePublisher> redisNotificationRealtimePublisher;
 
     public SseEmitter subscribe(Long userId) {
         String emitterId = UUID.randomUUID().toString();
@@ -46,6 +49,15 @@ public class SseService {
     }
 
     public void sendNotificationEvent(Long userId, String notificationType, Long notificationId, long unreadCount) {
+        if (redisNotificationRealtimePublisher.isPresent()) {
+            redisNotificationRealtimePublisher.get()
+                    .publish(userId, notificationType, notificationId, unreadCount);
+            return;
+        }
+        sendNotificationEventLocal(userId, notificationType, notificationId, unreadCount);
+    }
+
+    public void sendNotificationEventLocal(Long userId, String notificationType, Long notificationId, long unreadCount) {
         Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("type", "NOTIFICATION");
         payload.put("notification_type", notificationType);

--- a/refit-backend/src/main/resources/application-dev.yml
+++ b/refit-backend/src/main/resources/application-dev.yml
@@ -172,6 +172,10 @@ app:
   notification:
     async:
       enabled: false
+    realtime:
+      redis:
+        enabled: true
+        channel: notification.event.broadcast
   rate-limit:
     enabled: true
   kafka:

--- a/refit-backend/src/main/resources/application-prod.yml
+++ b/refit-backend/src/main/resources/application-prod.yml
@@ -173,6 +173,10 @@ app:
   notification:
     async:
       enabled: ${APP_NOTIFICATION_ASYNC_ENABLED:true}
+    realtime:
+      redis:
+        enabled: ${APP_NOTIFICATION_REALTIME_REDIS_ENABLED:true}
+        channel: notification.event.broadcast
   kafka:
     enabled: true
     topics:


### PR DESCRIPTION
  ## 변경 사항
  - SSE 알림이 다중 인스턴스 환경에서도 전달될 수 있도록 Redis Pub/Sub fan-out을 추가했습니다.

  ## 상세 내용
  - `SseService`의 알림 전송 경로에 Redis Pub/Sub fan-out을 적용해, 인스턴스 로컬 emitter 구조에서 발생할 수 있는 SSE 알림 누락을 보완했습니다.

  ## 체크리스트
  - [x] 기능이 정상적으로 동작하는지 확인했습니다.
  - [x] 기존 기능에 영향을 주지 않는지 확인했습니다.

  ## 리뷰 요청 사항
  - 

  ## 연관된 이슈
  - 

  ## 참고 자료 (선택)
