### PR TITLE
[ISSUE - #252] processed_events 중복 처리 시 재시도 누적 버그 수정

### DIFF
--- a/refit-backend/src/main/java/org/refit/refitbackend/global/idempotency/repository/ProcessedEventRepository.java
+++ b/refit-backend/src/main/java/org/refit/refitbackend/global/idempotency/repository/ProcessedEventRepository.java
@@ -1,7 +1,21 @@
 package org.refit.refitbackend.global.idempotency.repository;
 
 import org.refit.refitbackend.global.idempotency.entity.ProcessedEvent;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ProcessedEventRepository extends JpaRepository<ProcessedEvent, Long> {
+
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query(value = """
+            INSERT INTO processed_events (consumer_name, event_key, created_at, updated_at)
+            VALUES (:consumerName, :eventKey, now(), now())
+            ON CONFLICT (consumer_name, event_key) DO NOTHING
+            """, nativeQuery = true)
+    int insertIgnore(
+            @Param("consumerName") String consumerName,
+            @Param("eventKey") String eventKey
+    );
 }

--- a/refit-backend/src/main/java/org/refit/refitbackend/global/idempotency/service/ProcessedEventService.java
+++ b/refit-backend/src/main/java/org/refit/refitbackend/global/idempotency/service/ProcessedEventService.java
@@ -1,10 +1,9 @@
 package org.refit.refitbackend.global.idempotency.service;
 
 import lombok.RequiredArgsConstructor;
-import org.refit.refitbackend.global.idempotency.entity.ProcessedEvent;
 import org.refit.refitbackend.global.idempotency.repository.ProcessedEventRepository;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -12,12 +11,8 @@ public class ProcessedEventService {
 
     private final ProcessedEventRepository processedEventRepository;
 
+    @Transactional
     public boolean tryMarkProcessed(String consumerName, String eventKey) {
-        try {
-            processedEventRepository.saveAndFlush(ProcessedEvent.of(consumerName, eventKey));
-            return true;
-        } catch (DataIntegrityViolationException e) {
-            return false;
-        }
+        return processedEventRepository.insertIgnore(consumerName, eventKey) > 0;
     }
 }


### PR DESCRIPTION
  ## 변경 사항
  - `processed_events` 중복 처리 방식에서 발생하던 Kafka 재시도 및 DLQ 누적 문제를 수정했습니다.

  ## 상세 내용
  - 기존에는 `processed_events` 저장 시 unique constraint 예외를 발생시키고 이를 catch 하는 방식으로 중복 이벤트를 판별했습니다.
  - 하지만 동일 트랜잭션 내에서 DB 예외가 발생하면서 listener 트랜잭션이 실패로 전파될 수 있었고, 그 결과 Kafka가 동일 이벤트를 계속 재시도하다가 DLQ까지 누적되는 문제가 있었습니
  다.
  - 이를 해결하기 위해 PostgreSQL `ON CONFLICT DO NOTHING` 기반 insert 방식으로 변경했습니다.
  - 이제 중복 이벤트는 예외 없이 정상적으로 skip 처리되며, 불필요한 Kafka retry 및 DLQ 누적이 발생하지 않도록 개선했습니다.

  ## 체크리스트
  - [x] 기능이 정상적으로 동작하는지 확인했습니다.
  - [x] 기존 기능에 영향을 주지 않는지 확인했습니다.

  ## 리뷰 요청 사항
  -

  ## 연관된 이슈

  > #252 

  ## 참고 자료 (선택)
  - 